### PR TITLE
Ensure onboarding requires launcher permission

### DIFF
--- a/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
@@ -28,8 +28,8 @@ fun OnboardingScreen(
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
 
-    LaunchedEffect(uiState.allPermissionsGranted && uiState.isDefaultLauncher) {
-        if (uiState.allPermissionsGranted && uiState.isDefaultLauncher) {
+    LaunchedEffect(uiState.allPermissionsGranted) {
+        if (uiState.allPermissionsGranted) {
             viewModel.completeOnboarding()
             onOnboardingComplete()
         }
@@ -102,7 +102,7 @@ fun OnboardingScreen(
 
         Spacer(modifier = Modifier.height(32.dp))
 
-        if (uiState.allPermissionsGranted && uiState.isDefaultLauncher) {
+        if (uiState.allPermissionsGranted) {
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 colors = CardDefaults.cardColors(

--- a/app/src/main/java/com/talauncher/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/onboarding/OnboardingViewModel.kt
@@ -42,7 +42,7 @@ class OnboardingViewModel(
         _uiState.value = _uiState.value.copy(
             hasUsageStatsPermission = hasUsageStats,
             isDefaultLauncher = isDefaultLauncher,
-            allPermissionsGranted = hasUsageStats
+            allPermissionsGranted = hasUsageStats && isDefaultLauncher
         )
     }
 


### PR DESCRIPTION
## Summary
- require both the usage stats permission and default launcher status before marking onboarding complete
- simplify the onboarding screen logic to rely on the aggregated permission state

## Testing
- sh gradlew lint *(fails: Value 'C:\\Program Files\\Java\\jdk-24' given for org.gradle.java.home Gradle property is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68c86965b2448321ac0774bdf637cfd8