### PR TITLE
Fix essential app toggle behavior

### DIFF
--- a/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
@@ -64,11 +64,11 @@ fun SettingsScreen(
                 onUpdateMathDifficulty = viewModel::updateMathDifficulty
             )
             1 -> AppSelectionTab(
-                title = "Pinned Apps",
+                title = "Essential Apps",
                 subtitle = "Apps that will appear on your home screen",
                 apps = viewModel.getFilteredApps(),
                 selectedApps = uiState.pinnedApps.map { it.packageName }.toSet(),
-                onToggleApp = viewModel::togglePinnedApp,
+                onToggleApp = viewModel::toggleEssentialApp,
                 searchQuery = uiState.searchQuery,
                 onSearchQueryChange = viewModel::updateSearchQuery,
                 isLoading = uiState.isLoading

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
@@ -52,34 +52,13 @@ class SettingsViewModel(
         }
     }
 
-    fun togglePinnedApp(packageName: String) {
+    fun toggleEssentialApp(packageName: String) {
         viewModelScope.launch {
             val currentApp = appRepository.getApp(packageName)
             if (currentApp?.isPinned == true) {
                 appRepository.unpinApp(packageName)
             } else {
                 appRepository.pinApp(packageName)
-            }
-        }
-    }
-
-    fun toggleEssentialApp(packageName: String) {
-        viewModelScope.launch {
-            val currentApp = appRepository.getApp(packageName)
-            val installedApp = allInstalledApps.find { it.packageName == packageName }
-
-            if (currentApp != null) {
-                appRepository.updateDistractingStatus(packageName, !currentApp.isDistracting)
-            } else if (installedApp != null) {
-                appRepository.insertApp(
-                    AppInfo(
-                        packageName = packageName,
-                        appName = installedApp.appName,
-                        isPinned = false,
-                        isHidden = false,
-                        isDistracting = false
-                    )
-                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- align `toggleEssentialApp` with pin/unpin behavior in `SettingsViewModel`
- update the settings screen essential apps tab to call the corrected toggle

## Testing
- `bash gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c86b880158832182a9407a89a67d1d