### PR TITLE
Make usage stats helper suspend

### DIFF
--- a/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
@@ -7,7 +7,6 @@ import android.provider.Settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.talauncher.data.model.AppInfo
-import com.talauncher.data.model.AppUsage
 import com.talauncher.data.model.InstalledApp
 import com.talauncher.data.repository.AppRepository
 import com.talauncher.data.repository.SettingsRepository
@@ -51,7 +50,7 @@ class AppDrawerViewModel(
         }
     }
 
-    private fun getRecentApps(allApps: List<AppInfo>): List<AppInfo> {
+    private suspend fun getRecentApps(allApps: List<AppInfo>): List<AppInfo> {
         val topUsedApps = usageStatsHelper.getTopUsedApps(5)
         val appMap = allApps.associateBy { it.packageName }
 

--- a/app/src/main/java/com/talauncher/ui/insights/InsightsViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/insights/InsightsViewModel.kt
@@ -4,10 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.talauncher.data.model.AppUsage
 import com.talauncher.utils.UsageStatsHelper
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.concurrent.TimeUnit
 
 class InsightsViewModel(
@@ -33,20 +35,24 @@ class InsightsViewModel(
                 return@launch
             }
 
-            val usageStats = usageStatsHelper.getTodayUsageStats()
+            val usageStats = withContext(Dispatchers.IO) {
+                usageStatsHelper.getTodayUsageStats()
+            }
 
-            val appUsageWithNames = usageStats.mapNotNull { usage ->
-                val appName = usageStatsHelper.getAppName(usage.packageName)
-                if (appName != null) {
-                    AppUsageDisplay(
-                        packageName = usage.packageName,
-                        appName = appName,
-                        timeInForeground = usage.timeInForeground,
-                        formattedTime = formatTime(usage.timeInForeground)
-                    )
-                } else null
-            }.filter { it.timeInForeground > 0 }
-                .sortedByDescending { it.timeInForeground }
+            val appUsageWithNames = withContext(Dispatchers.IO) {
+                usageStats.mapNotNull { usage ->
+                    val appName = usageStatsHelper.getAppName(usage.packageName)
+                    if (appName != null) {
+                        AppUsageDisplay(
+                            packageName = usage.packageName,
+                            appName = appName,
+                            timeInForeground = usage.timeInForeground,
+                            formattedTime = formatTime(usage.timeInForeground)
+                        )
+                    } else null
+                }.filter { it.timeInForeground > 0 }
+                    .sortedByDescending { it.timeInForeground }
+            }
 
             val totalTime = appUsageWithNames.sumOf { it.timeInForeground }
 


### PR DESCRIPTION
## Summary
- make the usage stats helper query methods suspend and dispatch to Dispatchers.IO
- update InsightsViewModel and AppDrawerViewModel to call the suspend APIs from background contexts

## Testing
- ./gradlew lint *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c86b8f141c8321808252ff6b570fbe