### PR TITLE
Handle session expiry via repository

### DIFF
--- a/app/src/main/java/com/talauncher/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/SessionRepository.kt
@@ -3,6 +3,7 @@ package com.talauncher.data.repository
 import com.talauncher.data.database.AppSessionDao
 import com.talauncher.data.model.AppSession
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 
 class SessionRepository(private val appSessionDao: AppSessionDao) {
 
@@ -10,6 +11,11 @@ class SessionRepository(private val appSessionDao: AppSessionDao) {
 
     suspend fun getActiveSessionForApp(packageName: String): AppSession? =
         appSessionDao.getActiveSessionForApp(packageName)
+
+    suspend fun getExpiredSessions(): List<AppSession> {
+        val activeSessions = appSessionDao.getActiveSessions().first()
+        return activeSessions.filter { isSessionExpired(it) }
+    }
 
     suspend fun startSession(packageName: String, plannedDurationMinutes: Int): Long {
         val session = AppSession(


### PR DESCRIPTION
## Summary
- retain a single SessionRepository instance in MainActivity and reuse it during resume handling
- add a helper in SessionRepository to fetch expired sessions and end those that do not need a challenge
- trigger navigation back to the home screen when an expired session still requires a math challenge

## Testing
- sh gradlew lint -Dorg.gradle.java.home=$JAVA_HOME *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c86b7ffad4832190eb6f381a083402