### PR TITLE
Use IO dispatcher for package lookups

### DIFF
--- a/app/src/main/java/com/talauncher/data/repository/AppRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/AppRepository.kt
@@ -64,16 +64,17 @@ class AppRepository(
         appDao.updateDistractingStatus(packageName, isDistracting)
     }
 
-    private suspend fun getAppInfoFromPackage(packageName: String): AppInfo? {
-        val packageManager = context.packageManager
-        return try {
-            val appInfo = packageManager.getApplicationInfo(packageName, 0)
-            val appName = packageManager.getApplicationLabel(appInfo).toString()
-            AppInfo(packageName = packageName, appName = appName)
-        } catch (e: Exception) {
-            null
+    private suspend fun getAppInfoFromPackage(packageName: String): AppInfo? =
+        withContext(Dispatchers.IO) {
+            val packageManager = context.packageManager
+            try {
+                val appInfo = packageManager.getApplicationInfo(packageName, 0)
+                val appName = packageManager.getApplicationLabel(appInfo).toString()
+                AppInfo(packageName = packageName, appName = appName)
+            } catch (e: Exception) {
+                null
+            }
         }
-    }
 
     suspend fun getInstalledApps(): List<InstalledApp> = withContext(Dispatchers.IO) {
         val packageManager = context.packageManager


### PR DESCRIPTION
## Summary
- wrap getAppInfoFromPackage in Dispatchers.IO to ensure package manager queries run off the main thread
- keep pinApp and hideApp callers unchanged so they continue running on the main dispatcher

## Testing
- ./gradlew test *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ee6425f88321947da2aa1b475634