### PR TITLE
Use application context for repository launches

### DIFF
--- a/app/src/main/java/com/talauncher/MainActivity.kt
+++ b/app/src/main/java/com/talauncher/MainActivity.kt
@@ -53,7 +53,12 @@ class MainActivity : ComponentActivity() {
             val database = LauncherDatabase.getDatabase(this)
             val settingsRepository = SettingsRepository(database.settingsDao())
             val sessionRepository = SessionRepository(database.appSessionDao())
-            val appRepository = AppRepository(database.appDao(), this, settingsRepository, sessionRepository)
+            val appRepository = AppRepository(
+                database.appDao(),
+                applicationContext,
+                settingsRepository,
+                sessionRepository
+            )
             val permissionsHelper = PermissionsHelper(applicationContext)
             val usageStatsHelper = UsageStatsHelper(applicationContext, permissionsHelper)
 

--- a/app/src/main/java/com/talauncher/data/repository/AppRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/AppRepository.kt
@@ -10,6 +10,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 
+/**
+ * Repository providing app data and launch helpers.
+ *
+ * @param context Application context used for package queries and launching intents. Pass an
+ * application context so launches work correctly from non-Activity components.
+ */
 class AppRepository(
     private val appDao: AppDao,
     private val context: Context,

--- a/app/src/main/java/com/talauncher/ui/insights/InsightsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/insights/InsightsScreen.kt
@@ -56,7 +56,9 @@ fun InsightsScreen(
         if (!uiState.hasPermission) {
             PermissionCard(
                 onGrantPermission = {
-                    val intent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS)
+                    val intent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
                     context.startActivity(intent)
                 }
             )

--- a/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
@@ -80,7 +80,9 @@ fun OnboardingScreen(
             isCompleted = uiState.isDefaultLauncher,
             buttonText = if (uiState.isDefaultLauncher) "Completed" else "Set as Default",
             onButtonClick = {
-                val intent = Intent(Settings.ACTION_HOME_SETTINGS)
+                val intent = Intent(Settings.ACTION_HOME_SETTINGS).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
                 context.startActivity(intent)
             }
         )
@@ -95,7 +97,9 @@ fun OnboardingScreen(
             isCompleted = uiState.hasUsageStatsPermission,
             buttonText = if (uiState.hasUsageStatsPermission) "Completed" else "Grant Permission",
             onButtonClick = {
-                val intent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS)
+                val intent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
                 context.startActivity(intent)
             }
         )


### PR DESCRIPTION
## Summary
- pass the application context into `AppRepository` so launches work from non-activity scopes
- document that `AppRepository` expects an application context
- ensure onboarding and insights intents add `FLAG_ACTIVITY_NEW_TASK`

## Testing
- ./gradlew lint *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ee7b311c832198b6d749e96d5e81