### PR TITLE
Initialize repositories in MainActivity fields

### DIFF
--- a/app/src/main/java/com/talauncher/MainActivity.kt
+++ b/app/src/main/java/com/talauncher/MainActivity.kt
@@ -52,8 +52,13 @@ class MainActivity : ComponentActivity() {
         try {
             val database = LauncherDatabase.getDatabase(this)
             val settingsRepository = SettingsRepository(database.settingsDao())
-            val sessionRepository = SessionRepository(database.appSessionDao())
-            val appRepository = AppRepository(database.appDao(), this, settingsRepository, sessionRepository)
+            this.sessionRepository = SessionRepository(database.appSessionDao())
+            this.appRepository = AppRepository(
+                database.appDao(),
+                this,
+                settingsRepository,
+                this.sessionRepository
+            )
             val permissionsHelper = PermissionsHelper(applicationContext)
             val usageStatsHelper = UsageStatsHelper(applicationContext, permissionsHelper)
 


### PR DESCRIPTION
## Summary
- assign MainActivity's repositories to the activity fields so lifecycle callbacks can access them

## Testing
- ./gradlew test --console=plain --no-daemon *(fails: requires Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ee570e788321bee6a7bbe0be09a0