### PR TITLE
Update math challenge generation with difficulty key

### DIFF
--- a/app/src/main/java/com/talauncher/ui/components/MathChallengeDialog.kt
+++ b/app/src/main/java/com/talauncher/ui/components/MathChallengeDialog.kt
@@ -103,10 +103,15 @@ fun MathChallengeDialog(
     onDismiss: () -> Unit,
     isTimeExpired: Boolean = false  // If true, this is a mandatory challenge due to time expiration
 ) {
-    val problem = remember { MathGenerator.generateProblem(difficulty) }
+    val problem = remember(difficulty) { MathGenerator.generateProblem(difficulty) }
     var answerText by remember { mutableStateOf("") }
     var isError by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf("") }
+    LaunchedEffect(problem, difficulty) {
+        answerText = ""
+        isError = false
+        errorMessage = ""
+    }
     var timeLeft by remember { mutableStateOf(if (isTimeExpired) 30 else 0) }  // 30 seconds countdown for expired sessions
 
     // Auto-dismiss timer for expired sessions


### PR DESCRIPTION
## Summary
- regenerate the math challenge problem when the dialog difficulty changes by keying the remember call on the difficulty
- clear the answer and error state whenever the problem refreshes so the input starts blank

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ee5af4e483219dfb61fc880ac2f4