### PR TITLE
Fix launching distracting apps after setting time limit

### DIFF
--- a/app/src/main/java/com/talauncher/data/repository/AppRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/AppRepository.kt
@@ -106,7 +106,8 @@ class AppRepository(
         val app = getApp(packageName)
         val settings = settingsRepository.getSettingsSync()
 
-        if (!bypassFriction && app?.isDistracting == true) {
+        val requiresFriction = !bypassFriction && plannedDuration == null && app?.isDistracting == true
+        if (requiresFriction) {
             // Return false to indicate friction barrier should be shown
             return false
         }


### PR DESCRIPTION
## Summary
- treat time-limited launches of distracting apps as successful friction bypasses

## Testing
- `./gradlew test` *(fails: requires Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f4c97d0483218ee978923f13e46e