### PR TITLE
Ignore node_modules directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ crashlytics-build.properties
 
 # Kotlin temporary files
 .kotlin/
+
+node_modules/


### PR DESCRIPTION
## Summary
- add the node_modules/ directory to the root .gitignore so transient dependencies stay out of version control

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68c8ff219e9483219191ba4e7a985088