### PR TITLE
Add tests for uninstall permission handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
 
     testImplementation("junit:junit:4.13.2")
+    testImplementation("io.mockk:mockk:1.13.12")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.7.5")

--- a/app/src/main/java/com/talauncher/MainActivity.kt
+++ b/app/src/main/java/com/talauncher/MainActivity.kt
@@ -253,7 +253,13 @@ fun LauncherNavigationPager(
             2 -> {
                 // All Apps Screen
                 val appDrawerViewModel: AppDrawerViewModel = viewModel {
-                    AppDrawerViewModel(appRepository, settingsRepository, usageStatsHelper, onLaunchApp)
+                    AppDrawerViewModel(
+                        appRepository,
+                        settingsRepository,
+                        usageStatsHelper,
+                        permissionsHelper,
+                        onLaunchApp
+                    )
                 }
                 AppDrawerScreen(
                     viewModel = appDrawerViewModel

--- a/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
+++ b/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
@@ -5,11 +5,15 @@ import android.content.Context
 import android.os.Build
 import android.os.Process
 
-class PermissionsHelper(private val context: Context) {
+class PermissionsHelper(
+    private val context: Context,
+    private val sdkIntProvider: () -> Int = { Build.VERSION.SDK_INT }
+) {
 
     fun hasUsageStatsPermission(): Boolean {
         val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
-        val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val sdkInt = sdkIntProvider()
+        val mode = if (sdkInt >= Build.VERSION_CODES.Q) {
             appOps.unsafeCheckOpNoThrow(
                 AppOpsManager.OPSTR_GET_USAGE_STATS,
                 Process.myUid(),
@@ -18,6 +22,29 @@ class PermissionsHelper(private val context: Context) {
         } else {
             appOps.checkOpNoThrow(
                 AppOpsManager.OPSTR_GET_USAGE_STATS,
+                Process.myUid(),
+                context.packageName
+            )
+        }
+        return mode == AppOpsManager.MODE_ALLOWED
+    }
+
+    fun canUninstallOtherApps(): Boolean {
+        val sdkInt = sdkIntProvider()
+        if (sdkInt < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            return true
+        }
+
+        val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+        val mode = if (sdkInt >= Build.VERSION_CODES.Q) {
+            appOps.unsafeCheckOpNoThrow(
+                AppOpsManager.OPSTR_REQUEST_DELETE_PACKAGES,
+                Process.myUid(),
+                context.packageName
+            )
+        } else {
+            appOps.checkOpNoThrow(
+                AppOpsManager.OPSTR_REQUEST_DELETE_PACKAGES,
                 Process.myUid(),
                 context.packageName
             )

--- a/app/src/test/java/com/talauncher/ui/appdrawer/AppDrawerViewModelTest.kt
+++ b/app/src/test/java/com/talauncher/ui/appdrawer/AppDrawerViewModelTest.kt
@@ -1,0 +1,91 @@
+package com.talauncher.ui.appdrawer
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import com.talauncher.data.model.AppInfo
+import com.talauncher.data.model.LauncherSettings
+import com.talauncher.data.repository.AppRepository
+import com.talauncher.data.repository.SettingsRepository
+import com.talauncher.utils.PermissionsHelper
+import com.talauncher.utils.UsageStatsHelper
+import io.mockk.Runs
+import io.mockk.any
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppDrawerViewModelTest {
+
+    private val appRepository: AppRepository = mockk()
+    private val settingsRepository: SettingsRepository = mockk()
+    private val usageStatsHelper: UsageStatsHelper = mockk()
+    private val permissionsHelper: PermissionsHelper = mockk()
+
+    private val visibleApps = MutableStateFlow<List<AppInfo>>(emptyList())
+    private val hiddenApps = MutableStateFlow<List<AppInfo>>(emptyList())
+    private val settingsFlow = MutableStateFlow<LauncherSettings?>(LauncherSettings())
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { appRepository.getAllVisibleApps() } returns visibleApps
+        every { appRepository.getHiddenApps() } returns hiddenApps
+        every { settingsRepository.getSettings() } returns settingsFlow
+        every { usageStatsHelper.hasUsageStatsPermission() } returns false
+        coEvery { usageStatsHelper.getTopUsedApps(any()) } returns emptyList()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `uninstallApp opens settings when uninstall permission is denied`() = runTest(testDispatcher) {
+        every { permissionsHelper.canUninstallOtherApps() } returns false
+        val context: Context = mockk()
+        val intentSlot = slot<Intent>()
+        every { context.startActivity(capture(intentSlot)) } just Runs
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val packageName = "com.example.app"
+        viewModel.uninstallApp(context, packageName)
+
+        val intent = intentSlot.captured
+        assertEquals(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, intent.action)
+        assertEquals(Uri.parse("package:$packageName"), intent.data)
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    private fun createViewModel(): AppDrawerViewModel {
+        return AppDrawerViewModel(
+            appRepository = appRepository,
+            settingsRepository = settingsRepository,
+            usageStatsHelper = usageStatsHelper,
+            permissionsHelper = permissionsHelper,
+            onLaunchApp = null
+        )
+    }
+}

--- a/app/src/test/java/com/talauncher/utils/PermissionsHelperTest.kt
+++ b/app/src/test/java/com/talauncher/utils/PermissionsHelperTest.kt
@@ -1,0 +1,78 @@
+package com.talauncher.utils
+
+import android.app.AppOpsManager
+import android.content.Context
+import android.os.Build
+import io.mockk.any
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PermissionsHelperTest {
+
+    private val context: Context = mockk()
+    private val appOpsManager: AppOpsManager = mockk()
+
+    @BeforeTest
+    fun setUp() {
+        every { context.getSystemService(Context.APP_OPS_SERVICE) } returns appOpsManager
+        every { context.packageName } returns "com.talauncher.test"
+    }
+
+    @AfterTest
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `canUninstallOtherApps returns true for pre Android 14 devices`() {
+        val helper = PermissionsHelper(context) { Build.VERSION_CODES.TIRAMISU }
+
+        assertTrue(helper.canUninstallOtherApps())
+        verify(exactly = 0) { appOpsManager.unsafeCheckOpNoThrow(any(), any(), any()) }
+        verify(exactly = 0) { appOpsManager.checkOpNoThrow(any(), any(), any()) }
+    }
+
+    @Test
+    fun `canUninstallOtherApps returns true when permission granted on Android 14 plus`() {
+        every {
+            appOpsManager.unsafeCheckOpNoThrow(
+                AppOpsManager.OPSTR_REQUEST_DELETE_PACKAGES,
+                any(),
+                any()
+            )
+        } returns AppOpsManager.MODE_ALLOWED
+
+        val helper = PermissionsHelper(context) { Build.VERSION_CODES.UPSIDE_DOWN_CAKE }
+
+        assertTrue(helper.canUninstallOtherApps())
+        verify(exactly = 1) {
+            appOpsManager.unsafeCheckOpNoThrow(
+                AppOpsManager.OPSTR_REQUEST_DELETE_PACKAGES,
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `canUninstallOtherApps returns false when permission denied on Android 14 plus`() {
+        every {
+            appOpsManager.unsafeCheckOpNoThrow(
+                AppOpsManager.OPSTR_REQUEST_DELETE_PACKAGES,
+                any(),
+                any()
+            )
+        } returns AppOpsManager.MODE_ERRORED
+
+        val helper = PermissionsHelper(context) { Build.VERSION_CODES.UPSIDE_DOWN_CAKE }
+
+        assertFalse(helper.canUninstallOtherApps())
+    }
+}


### PR DESCRIPTION
## Summary
- add a `canUninstallOtherApps` helper with API-specific logic for uninstall permissions
- update the app drawer view model to use the helper and fall back to the app settings screen when uninstall permission is unavailable
- introduce unit tests covering uninstall permission behavior and wire in required mocking/test dependencies

## Testing
- `./gradlew test` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ff357c348321adcffe67e4146ff8