### PR TITLE
Centralize app name usage

### DIFF
--- a/app/src/main/java/com/talauncher/MainActivity.kt
+++ b/app/src/main/java/com/talauncher/MainActivity.kt
@@ -16,11 +16,13 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.talauncher.R
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import com.talauncher.data.database.LauncherDatabase
@@ -110,7 +112,7 @@ class MainActivity : ComponentActivity() {
                 }
             }
         } catch (error: Throwable) {
-            Log.e(TAG, "Error starting TALauncher", error)
+            Log.e(TAG, "Error starting ${getString(R.string.app_name)}", error)
             reportStartupError(error)
         }
     }
@@ -265,13 +267,14 @@ fun LauncherNavigationPager(
 
 @Composable
 fun LoadingScreen() {
+    val appName = stringResource(R.string.app_name)
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
         Text(
-            text = "TALauncher",
+            text = appName,
             style = MaterialTheme.typography.displayMedium,
             color = MaterialTheme.colorScheme.primary,
             textAlign = TextAlign.Center
@@ -308,6 +311,7 @@ private fun StartupErrorScreen(error: Throwable) {
         error.localizedMessage?.takeIf { it.isNotBlank() }
             ?: "${error::class.qualifiedName ?: error::class.simpleName}"
     }
+    val appName = stringResource(R.string.app_name)
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -321,7 +325,7 @@ private fun StartupErrorScreen(error: Throwable) {
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "TALauncher ran into a problem",
+                text = "$appName ran into a problem",
                 style = MaterialTheme.typography.headlineSmall,
                 color = MaterialTheme.colorScheme.error
             )

--- a/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
@@ -220,7 +220,9 @@ class AppDrawerViewModel(
     }
 
     private fun notifyPermissionRequired(context: Context) {
-        Toast.makeText(context, R.string.uninstall_permission_required, Toast.LENGTH_LONG).show()
+        val appName = context.getString(R.string.app_name)
+        val message = context.getString(R.string.uninstall_permission_required, appName)
+        Toast.makeText(context, message, Toast.LENGTH_LONG).show()
         permissionsHelper.openUninstallPermissionSettings()
     }
 }

--- a/app/src/main/java/com/talauncher/ui/insights/InsightsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/insights/InsightsScreen.kt
@@ -12,11 +12,13 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.talauncher.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -110,6 +112,7 @@ fun InsightsScreen(
 
 @Composable
 fun PermissionCard(onGrantPermission: () -> Unit) {
+    val appName = stringResource(R.string.app_name)
     Card(
         modifier = Modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
@@ -131,7 +134,8 @@ fun PermissionCard(onGrantPermission: () -> Unit) {
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
-                text = "To view usage statistics, TALauncher needs access to usage data. This permission allows the app to show you how much time you spend in different applications.",
+                text = "To view usage statistics, $appName needs access to usage data. " +
+                    "This permission allows the app to show you how much time you spend in different applications.",
                 textAlign = TextAlign.Center,
                 color = MaterialTheme.colorScheme.onErrorContainer
             )

--- a/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
@@ -15,10 +15,12 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.talauncher.R
 
 @Composable
 fun OnboardingScreen(
@@ -27,6 +29,7 @@ fun OnboardingScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
+    val appName = stringResource(R.string.app_name)
 
     LaunchedEffect(uiState.allPermissionsGranted) {
         if (uiState.allPermissionsGranted) {
@@ -45,7 +48,7 @@ fun OnboardingScreen(
         Spacer(modifier = Modifier.height(32.dp))
 
         Text(
-            text = "Welcome to TALauncher",
+            text = "Welcome to $appName",
             style = MaterialTheme.typography.displayMedium,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.primary,
@@ -76,7 +79,7 @@ fun OnboardingScreen(
         OnboardingStepCard(
             icon = Icons.Default.Home,
             title = "Set as Default Launcher",
-            description = "Make TALauncher your default home screen",
+            description = "Make $appName your default home screen",
             isCompleted = uiState.isDefaultLauncher,
             buttonText = if (uiState.isDefaultLauncher) "Completed" else "Set as Default",
             onButtonClick = {
@@ -132,7 +135,7 @@ fun OnboardingScreen(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
-                        text = "TALauncher is ready to help you focus",
+                        text = "$appName is ready to help you focus",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
                         textAlign = TextAlign.Center

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,5 +12,5 @@
     <string name="app_blocked">This app is blocked in Focus Mode</string>
     <string name="why_open_app">Why do you want to open this app?</string>
     <string name="continue_to_app">Continue to App</string>
-    <string name="uninstall_permission_required">Enable &quot;Uninstall other apps&quot; access so TALauncher can remove apps.</string>
+    <string name="uninstall_permission_required">Enable &quot;Uninstall other apps&quot; access so %1$s can remove apps.</string>
 </resources>


### PR DESCRIPTION
## Summary
- load the app name from the existing string resource wherever it is displayed or composed
- ensure onboarding, insights, and loading screens interpolate the shared app name value
- update the uninstall permission message to format with the shared app name string

## Testing
- ./gradlew test *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9141fc990832180cb23f8374818ff