### PR TITLE
Route app refresh actions through MainViewModel

### DIFF
--- a/app/src/main/java/com/talauncher/data/database/AppDao.kt
+++ b/app/src/main/java/com/talauncher/data/database/AppDao.kt
@@ -30,6 +30,9 @@ interface AppDao {
     @Delete
     suspend fun deleteApp(app: AppInfo)
 
+    @Query("UPDATE app_info SET appName = :appName WHERE packageName = :packageName")
+    suspend fun updateAppName(packageName: String, appName: String)
+
     @Query("UPDATE app_info SET isPinned = :isPinned, pinnedOrder = :order WHERE packageName = :packageName")
     suspend fun updatePinnedStatus(packageName: String, isPinned: Boolean, order: Int = 0)
 


### PR DESCRIPTION
## Summary
- create a MainViewModel factory that owns session and app refresh routines for the activity lifecycle
- update the Room DAO and repository to perform targeted app-name updates during sync
- trigger installed app and session refreshes via MainViewModel when the launcher resumes

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c913e4c81483219e7ba0b135f4e4a9