### PR TITLE
Improve permission prompt handling

### DIFF
--- a/app/src/main/java/com/talauncher/MainActivity.kt
+++ b/app/src/main/java/com/talauncher/MainActivity.kt
@@ -119,7 +119,8 @@ class MainActivity : ComponentActivity() {
                                 message = errorState.message,
                                 stackTrace = errorState.stackTrace,
                                 onDismiss = { errorHandler.dismissError() },
-                                onRetry = errorState.onRetry
+                                onRetry = errorState.onRetry,
+                                retryButtonText = errorState.retryButtonText
                             )
                         }
 

--- a/app/src/main/java/com/talauncher/ui/components/ErrorDialog.kt
+++ b/app/src/main/java/com/talauncher/ui/components/ErrorDialog.kt
@@ -19,7 +19,8 @@ fun ErrorDialog(
     message: String,
     stackTrace: String? = null,
     onDismiss: () -> Unit,
-    onRetry: (() -> Unit)? = null
+    onRetry: (() -> Unit)? = null,
+    retryButtonText: String = "Retry"
 ) {
     Dialog(
         onDismissRequest = onDismiss,
@@ -93,7 +94,7 @@ fun ErrorDialog(
                                 onRetry()
                             }
                         ) {
-                            Text("Retry")
+                            Text(retryButtonText)
                         }
                         Spacer(modifier = Modifier.width(12.dp))
                     }

--- a/app/src/main/java/com/talauncher/utils/ErrorHandler.kt
+++ b/app/src/main/java/com/talauncher/utils/ErrorHandler.kt
@@ -4,7 +4,13 @@ import java.io.PrintWriter
 import java.io.StringWriter
 
 interface ErrorHandler {
-    fun showError(title: String, message: String, throwable: Throwable? = null, onRetry: (() -> Unit)? = null)
+    fun showError(
+        title: String,
+        message: String,
+        throwable: Throwable? = null,
+        onRetry: (() -> Unit)? = null,
+        retryButtonText: String = "Retry"
+    )
     fun requestPermission(permission: String, rationale: String, onResult: (Boolean) -> Unit)
 }
 

--- a/app/src/main/java/com/talauncher/utils/MainErrorHandler.kt
+++ b/app/src/main/java/com/talauncher/utils/MainErrorHandler.kt
@@ -1,8 +1,10 @@
 package com.talauncher.utils
 
-import android.Manifest
 import android.app.Activity
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,7 +16,8 @@ data class ErrorState(
     val title: String = "",
     val message: String = "",
     val stackTrace: String? = null,
-    val onRetry: (() -> Unit)? = null
+    val onRetry: (() -> Unit)? = null,
+    val retryButtonText: String = "Retry"
 )
 
 class MainErrorHandler(private val activity: Activity) : ErrorHandler {
@@ -22,20 +25,33 @@ class MainErrorHandler(private val activity: Activity) : ErrorHandler {
     private val _errorState = MutableStateFlow(ErrorState())
     val errorState: StateFlow<ErrorState> = _errorState.asStateFlow()
 
-    private var permissionCallback: ((Boolean) -> Unit)? = null
+    private data class PermissionRequest(
+        val permission: String,
+        val rationale: String,
+        val onResult: (Boolean) -> Unit
+    )
+
+    private var currentPermissionRequest: PermissionRequest? = null
 
     companion object {
         private const val PERMISSION_REQUEST_CODE = 1001
     }
 
-    override fun showError(title: String, message: String, throwable: Throwable?, onRetry: (() -> Unit)?) {
+    override fun showError(
+        title: String,
+        message: String,
+        throwable: Throwable?,
+        onRetry: (() -> Unit)?,
+        retryButtonText: String
+    ) {
         val stackTrace = throwable?.let { ErrorUtils.getStackTraceString(it) }
         _errorState.value = ErrorState(
             isVisible = true,
             title = title,
             message = message,
             stackTrace = stackTrace,
-            onRetry = onRetry
+            onRetry = onRetry,
+            retryButtonText = retryButtonText
         )
     }
 
@@ -46,8 +62,8 @@ class MainErrorHandler(private val activity: Activity) : ErrorHandler {
             return
         }
 
-        // Store callback for later use
-        permissionCallback = onResult
+        // Track the active permission request so we can handle retries or permanent denials
+        currentPermissionRequest = PermissionRequest(permission, rationale, onResult)
 
         // Show rationale if needed
         if (ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
@@ -57,7 +73,8 @@ class MainErrorHandler(private val activity: Activity) : ErrorHandler {
                 null,
                 onRetry = {
                     requestPermissionInternal(permission)
-                }
+                },
+                retryButtonText = "Try Again"
             )
         } else {
             requestPermissionInternal(permission)
@@ -65,6 +82,7 @@ class MainErrorHandler(private val activity: Activity) : ErrorHandler {
     }
 
     private fun requestPermissionInternal(permission: String) {
+        dismissError()
         ActivityCompat.requestPermissions(activity, arrayOf(permission), PERMISSION_REQUEST_CODE)
     }
 
@@ -73,10 +91,56 @@ class MainErrorHandler(private val activity: Activity) : ErrorHandler {
     }
 
     fun onPermissionResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
-        if (requestCode == PERMISSION_REQUEST_CODE) {
-            val granted = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
-            permissionCallback?.invoke(granted)
-            permissionCallback = null
+        if (requestCode != PERMISSION_REQUEST_CODE) {
+            return
+        }
+
+        val request = currentPermissionRequest ?: return
+        if (permissions.isEmpty() || permissions[0] != request.permission) {
+            return
+        }
+
+        val granted = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
+        if (granted) {
+            request.onResult(true)
+            currentPermissionRequest = null
+            dismissError()
+            return
+        }
+
+        request.onResult(false)
+
+        val shouldShowRationale = ActivityCompat.shouldShowRequestPermissionRationale(activity, request.permission)
+        if (shouldShowRationale) {
+            showError(
+                "Permission Required",
+                request.rationale,
+                null,
+                onRetry = {
+                    requestPermissionInternal(request.permission)
+                },
+                retryButtonText = "Try Again"
+            )
+        } else {
+            showError(
+                "Permission Required",
+                request.rationale + "\n\nEnable this permission in system settings to continue.",
+                null,
+                onRetry = {
+                    openAppSettings()
+                },
+                retryButtonText = "Open Settings"
+            )
+        }
+    }
+
+    private fun openAppSettings() {
+        dismissError()
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", activity.packageName, null)
+        }
+        if (intent.resolveActivity(activity.packageManager) != null) {
+            activity.startActivity(intent)
         }
     }
 


### PR DESCRIPTION
## Summary
- add configurable retry button labels so permission dialogs can guide users to retry or open settings
- enhance `MainErrorHandler` to re-request permissions when possible and surface a popup directing users to system settings when permanently denied

## Testing
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 --console=plain lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c97fe9fa308321b92c7a6bb9b25fa9