### PR TITLE
Fix overlay permissions for Android 15

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,9 @@
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application
         android:allowBackup="true"
@@ -38,7 +40,12 @@
         <service
             android:name=".service.OverlayService"
             android:enabled="true"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <meta-data
+                android:name="android.app.special_use_fgs_reasons"
+                android:resource="@array/overlay_special_use_fgs_reasons" />
+        </service>
 
     </application>
 

--- a/app/src/main/java/com/talauncher/MainActivity.kt
+++ b/app/src/main/java/com/talauncher/MainActivity.kt
@@ -59,6 +59,14 @@ class MainActivity : ComponentActivity() {
             Log.w(TAG, "Foreground service permission not granted. Overlay service may fail to start on API 28+.")
         }
 
+        if (!permissionsHelper.hasForegroundServiceSpecialUsePermission()) {
+            Log.w(TAG, "Special use foreground service permission not granted. Overlay service may fail on Android 14+.")
+        }
+
+        if (!permissionsHelper.hasPostNotificationsPermission()) {
+            Log.w(TAG, "Notification permission not granted. Foreground overlay notifications cannot be shown.")
+        }
+
         if (!permissionsHelper.hasSystemAlertWindowPermission()) {
             Log.w(TAG, "System alert window permission not granted. App overlays will not work.")
         }

--- a/app/src/main/java/com/talauncher/service/OverlayService.kt
+++ b/app/src/main/java/com/talauncher/service/OverlayService.kt
@@ -101,6 +101,7 @@ class OverlayService : Service() {
             },
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
                     WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
+                    WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
                     WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
                     WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON,
             PixelFormat.TRANSLUCENT
@@ -177,6 +178,7 @@ class OverlayService : Service() {
             },
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
                     WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
+                    WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
                     WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
                     WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON,
             PixelFormat.TRANSLUCENT

--- a/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.talauncher.ui.home
 
+import android.app.ForegroundServiceStartNotAllowedException
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -483,10 +484,17 @@ class HomeViewModel(
             return
         }
 
+        if (!permissionsHelper.hasPostNotificationsPermission()) {
+            Log.w(TAG, "Notification permission not granted, cannot start overlay service")
+            return
+        }
+
         try {
             ContextCompat.startForegroundService(ctx, intent)
         } catch (e: SecurityException) {
             Log.e(TAG, "SecurityException starting overlay service for action ${intent.action}. Check manifest permissions.", e)
+        } catch (e: ForegroundServiceStartNotAllowedException) {
+            Log.e(TAG, "ForegroundServiceStartNotAllowedException for action ${intent.action}. Consider bringing the app to the foreground before starting the overlay service.", e)
         } catch (e: IllegalStateException) {
             Log.e(TAG, "Unable to start overlay service for action ${intent.action}", e)
         } catch (e: Exception) {

--- a/app/src/main/java/com/talauncher/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/onboarding/OnboardingViewModel.kt
@@ -46,17 +46,23 @@ class OnboardingViewModel(
         val hasUsageStats = permissionsHelper.hasUsageStatsPermission()
         val isDefaultLauncher = usageStatsHelper.isDefaultLauncher()
         val hasSystemAlertWindow = permissionsHelper.hasSystemAlertWindowPermission()
+        val hasPostNotifications = permissionsHelper.hasPostNotificationsPermission()
 
         _uiState.value = _uiState.value.copy(
             hasUsageStatsPermission = hasUsageStats,
             isDefaultLauncher = isDefaultLauncher,
             hasSystemAlertWindowPermission = hasSystemAlertWindow,
-            allPermissionsGranted = hasUsageStats && isDefaultLauncher && hasSystemAlertWindow
+            hasPostNotificationsPermission = hasPostNotifications,
+            allPermissionsGranted = hasUsageStats && isDefaultLauncher && hasSystemAlertWindow && hasPostNotifications
         )
     }
 
     fun requestSystemAlertWindowPermission() {
         permissionsHelper.requestSystemAlertWindowPermission()
+    }
+
+    fun refreshPermissions() {
+        checkPermissions()
     }
 
     fun completeOnboarding() {
@@ -70,6 +76,7 @@ data class OnboardingUiState(
     val hasUsageStatsPermission: Boolean = false,
     val isDefaultLauncher: Boolean = false,
     val hasSystemAlertWindowPermission: Boolean = false,
+    val hasPostNotificationsPermission: Boolean = false,
     val allPermissionsGranted: Boolean = false,
     val isOnboardingCompleted: Boolean = false
 )

--- a/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
+++ b/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
@@ -43,6 +43,28 @@ class PermissionsHelper(private val context: Context) {
         }
     }
 
+    fun hasPostNotificationsPermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+
+    fun hasForegroundServiceSpecialUsePermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.FOREGROUND_SERVICE_SPECIAL_USE
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+
     fun requestSystemAlertWindowPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(context)) {
             val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION).apply {
@@ -57,14 +79,21 @@ class PermissionsHelper(private val context: Context) {
     }
 
     fun hasForegroundServicePermission(): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            ContextCompat.checkSelfPermission(
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val hasStandardPermission = ContextCompat.checkSelfPermission(
                 context,
                 Manifest.permission.FOREGROUND_SERVICE
             ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            true // Permission not required for API < 28
+            if (!hasStandardPermission) {
+                return false
+            }
         }
+
+        if (!hasForegroundServiceSpecialUsePermission()) {
+            return false
+        }
+
+        return true
     }
 
     fun openUninstallPermissionSettings() {

--- a/app/src/main/res/values/fgs_reasons.xml
+++ b/app/src/main/res/values/fgs_reasons.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="overlay_special_use_fgs_reasons">
+        <item>critical_app_functionality</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
## Summary
- request the post notifications and special-use foreground service permissions needed to run the overlay service on Android 15
- update permission helpers, onboarding, and the home overlay launcher to verify notification permission and handle foreground service restrictions
- adjust overlay window flags and register the service's special-use reason so the countdown dialog can render over other apps

## Testing
- `./gradlew lint` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9803cf82c8321a4f34325dccc812d