### PR TITLE
Ensure home button returns to main screen

### DIFF
--- a/app/src/main/java/com/talauncher/MainActivity.kt
+++ b/app/src/main/java/com/talauncher/MainActivity.kt
@@ -151,6 +151,8 @@ class MainActivity : ComponentActivity() {
         super.onResume()
         // Check for expired sessions when returning to launcher
         checkExpiredSessions()
+        // Always navigate back to the home page when the launcher becomes visible
+        shouldNavigateToHome = true
     }
 
     override fun onRequestPermissionsResult(


### PR DESCRIPTION
## Summary
- force a navigation back to the home page whenever the launcher activity resumes so the Home button consistently lands on the main screen

## Testing
- ./gradlew test *(fails: Java home configured for Gradle points to a Windows path in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c98a3b6dc48321b881270eb883a1aa