### PR TITLE
Ensure session overlays survive background restrictions

### DIFF
--- a/app/src/main/java/com/talauncher/MainActivity.kt
+++ b/app/src/main/java/com/talauncher/MainActivity.kt
@@ -262,7 +262,14 @@ fun LauncherNavigationPager(
                 // Main/Home Screen with pinned apps
                 val context = LocalContext.current
                 val homeViewModel: HomeViewModel = viewModel {
-                    HomeViewModel(appRepository, settingsRepository, onLaunchApp, sessionRepository, context)
+                    HomeViewModel(
+                        appRepository,
+                        settingsRepository,
+                        onLaunchApp,
+                        sessionRepository,
+                        context,
+                        permissionsHelper
+                    )
                 }
                 HomeScreen(
                     viewModel = homeViewModel,

--- a/app/src/main/res/drawable/ic_overlay_notification.xml
+++ b/app/src/main/res/drawable/ic_overlay_notification.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,2a10,10 0 1,0 10,10A10,10 0 0,0 12,2Zm0,5a1.5,1.5 0 1,1 -1.5,1.5A1.5,1.5 0 0,1 12,7Zm-1.25,4h2.5v7h-2.5z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,11 @@
     <string name="why_open_app">Why do you want to open this app?</string>
     <string name="continue_to_app">Continue to App</string>
     <string name="uninstall_permission_required">Enable &quot;Uninstall other apps&quot; access so %1$s can remove apps.</string>
+    <string name="overlay_permission_required">Enable &quot;Display over other apps&quot; access so %1$s can gently end sessions when time is up.</string>
+    <string name="session_overlay_notification_channel_name">Session reminders</string>
+    <string name="session_overlay_notification_channel_description">Allows %1$s to keep session limit prompts visible while other apps are open.</string>
+    <string name="session_overlay_notification_title">Mindful session running</string>
+    <string name="session_overlay_notification_text">%1$s is guiding your time while you use %2$s.</string>
     <string name="rename_app_action_label">Rename app</string>
     <string name="rename_app_action_description">Change how this app is displayed in TALauncher.</string>
     <string name="rename_app_dialog_title">Rename %1$s</string>


### PR DESCRIPTION
## Summary
- request overlay permission again when time-limit dialogs need to surface, prompt the user, and fall back to returning home when missing
- start the session overlay as a foreground service with a dedicated notification channel so countdowns and prompts show reliably in other apps
- wire the home screen ViewModel with the shared PermissionsHelper and add notification resources for the new foreground service

## Testing
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME lint --console=plain` *(fails: Android SDK missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c99690ad4c8321a70e01eb1cb9349c