### PR TITLE
Improve overlay overlay compatibility

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,11 @@
     <string name="overlay_permission_required_confirm">Open settings</string>
     <string name="overlay_permission_required_dismiss">Not now</string>
     <string name="overlay_permission_generic_app">this app</string>
+    <string name="overlay_notification_channel_name">Focus reminders</string>
+    <string name="overlay_notification_channel_description">Keeps TALauncher active while showing focus reminders over other apps.</string>
+    <string name="overlay_notification_countdown">Time is almost up in %1$s (%2$d s remaining).</string>
+    <string name="overlay_notification_decision">Decide how to continue with %1$s.</string>
+    <string name="overlay_notification_default">Focus reminder active.</string>
     <string-array name="motivational_quotes">
         <item>Every tap is a choice—make it count.</item>
         <item>Stay focused on what truly matters right now.</item>


### PR DESCRIPTION
## Summary
- add the foreground service permission and notification strings required for overlay reminders
- refactor `OverlayService` to run as a foreground service with notification updates and modern window flags
- update `HomeViewModel` service launches to use `startForegroundService` when needed so overlays work from the background

## Testing
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 --no-daemon --console=plain lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b92e66b88321a175b697b68dee95