### PR TITLE
Restrict OverlayService to internal callers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,20 +48,12 @@
         <service
             android:name=".service.OverlayService"
             android:enabled="true"
-            android:exported="true"
+            android:exported="false"
             android:foregroundServiceType="specialUse">
 
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="session_overlay_management" />
-
-            <intent-filter>
-                <action android:name="show_countdown" />
-                <action android:name="show_decision" />
-                <action android:name="show_math_challenge" />
-                <action android:name="hide_overlay" />
-            </intent-filter>
-
         </service>
 
     </application>


### PR DESCRIPTION
## Summary
- mark OverlayService as non-exported so it is no longer available to other apps
- remove the redundant intent filter now that only explicit intents are used internally

## Testing
- `./gradlew -Dorg.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2 lint --console=plain` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cca916af748321acf7f1ca1ca48727