### PR TITLE
Use math challenge difficulty from settings on home screen

### DIFF
--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -517,7 +517,7 @@ fun HomeScreen(
             run {
                 val selectedPackage = uiState.selectedAppForMathChallenge ?: return@run
                 MathChallengeDialog(
-                    difficulty = "medium", // Could be made configurable
+                    difficulty = uiState.mathChallengeDifficulty,
                     onCorrect = {
                         viewModel.onMathChallengeCompleted(selectedPackage)
                     },


### PR DESCRIPTION
## Summary
- pass the configured math challenge difficulty from HomeUiState into MathChallengeDialog so the home screen respects user settings

## Testing
- `./gradlew test` *(fails: Value 'C:\\Program Files\\Java\\jdk-24' given for org.gradle.java.home Gradle property is invalid (Java home supplied is invalid))*

------
https://chatgpt.com/codex/tasks/task_e_68cca90986108321b10ae30facc7898a