### PR TITLE
Add daily high and low weather display

### DIFF
--- a/app/src/main/java/com/talauncher/ui/components/WeatherDisplay.kt
+++ b/app/src/main/java/com/talauncher/ui/components/WeatherDisplay.kt
@@ -5,7 +5,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -18,11 +17,16 @@ fun WeatherDisplay(
     weatherData: WeatherData?,
     modifier: Modifier = Modifier,
     showTemperature: Boolean = true,
-    temperatureUnit: String = "celsius"
+    temperatureUnit: String = "celsius",
+    dailyHigh: Double? = null,
+    dailyLow: Double? = null
 ) {
     if (weatherData != null) {
         val convertedTemperature = convertTemperature(weatherData.temperature, temperatureUnit)
         val unitSuffix = getTemperatureSuffix(temperatureUnit)
+        val showDailyRange = dailyHigh != null && dailyLow != null
+        val convertedHigh = dailyHigh?.let { convertTemperature(it, temperatureUnit).roundToInt() }
+        val convertedLow = dailyLow?.let { convertTemperature(it, temperatureUnit).roundToInt() }
         Row(
             modifier = modifier,
             verticalAlignment = Alignment.CenterVertically,
@@ -35,7 +39,14 @@ fun WeatherDisplay(
                 color = MaterialTheme.colorScheme.onBackground
             )
 
-            if (showTemperature) {
+            if (showDailyRange && convertedHigh != null && convertedLow != null) {
+                Text(
+                    text = "H ${convertedHigh}°$unitSuffix  L ${convertedLow}°$unitSuffix",
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            } else if (showTemperature) {
                 Text(
                     text = "${convertedTemperature.roundToInt()}°$unitSuffix",
                     fontSize = 14.sp,

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -157,10 +157,14 @@ fun HomeScreen(
                         // Weather display next to time
                         if (uiState.weatherDisplay != "off" && uiState.weatherData != null) {
                             Spacer(modifier = Modifier.width(12.dp))
+                            val shouldShowTemperature = uiState.weatherDisplay != "daily" ||
+                                uiState.weatherDailyHigh == null || uiState.weatherDailyLow == null
                             com.talauncher.ui.components.WeatherDisplay(
                                 weatherData = uiState.weatherData,
-                                showTemperature = true,
-                                temperatureUnit = uiState.weatherTemperatureUnit
+                                showTemperature = shouldShowTemperature,
+                                temperatureUnit = uiState.weatherTemperatureUnit,
+                                dailyHigh = if (uiState.weatherDisplay == "daily") uiState.weatherDailyHigh else null,
+                                dailyLow = if (uiState.weatherDisplay == "daily") uiState.weatherDailyLow else null
                             )
                         }
                     }


### PR DESCRIPTION
## Summary
- enhance the weather pill so the daily mode shows high and low temperatures alongside the icon
- fetch and store daily forecast values in the home view model while keeping state clean when the weather display is disabled
- adjust the home screen to pass the new data and fall back to current temperature if the daily range is unavailable

## Testing
- `./gradlew test` *(fails: Value 'C:\\Program Files\\Java\\jdk-24' given for org.gradle.java.home Gradle property is invalid (Java home supplied is invalid))*

------
https://chatgpt.com/codex/tasks/task_e_68ccc0a41a5883219f0d297ba222f234