### PR TITLE
Refactor app drawer search to reuse shared component

### DIFF
--- a/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.talauncher.R
 import com.talauncher.data.model.AppInfo
+import com.talauncher.ui.components.AppSearchBar
 import com.talauncher.ui.components.MathChallengeDialog
 import com.talauncher.ui.components.TimeLimitDialog
 import com.talauncher.ui.theme.*
@@ -225,47 +226,14 @@ fun AppDrawerScreen(
                 ),
                 border = BorderStroke(2.dp, PrimerBlue.copy(alpha = 0.3f))
             ) {
-                OutlinedTextField(
+                AppSearchBar(
                     value = searchQuery,
                     onValueChange = { searchQuery = it },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .focusRequester(focusRequester),
-                    placeholder = {
-                        Text(
-                            text = "Search apps...",
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                    },
-                    leadingIcon = {
-                        Text(
-                            text = "Search",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = PrimerGray600,
-                            modifier = Modifier.padding(start = PrimerSpacing.xs)
-                        )
-                    },
-                    trailingIcon = {
-                        if (searchQuery.isNotEmpty()) {
-                            TextButton(
-                                onClick = {
-                                    searchQuery = ""
-                                    keyboardController?.hide()
-                                },
-                                colors = ButtonDefaults.textButtonColors(
-                                    contentColor = PrimerGray600
-                                ),
-                                contentPadding = PaddingValues(
-                                    horizontal = PrimerSpacing.xs,
-                                    vertical = 0.dp
-                                )
-                            ) {
-                                Text(
-                                    text = "Clear",
-                                    style = MaterialTheme.typography.labelMedium
-                                )
-                            }
-                        }
+                    modifier = Modifier.fillMaxWidth(),
+                    focusRequester = focusRequester,
+                    onClear = {
+                        searchQuery = ""
+                        keyboardController?.hide()
                     },
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                     keyboardActions = KeyboardActions(
@@ -273,7 +241,6 @@ fun AppDrawerScreen(
                             keyboardController?.hide()
                         }
                     ),
-                    singleLine = true,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = PrimerBlue,
                         unfocusedBorderColor = PrimerGray300,

--- a/app/src/main/java/com/talauncher/ui/components/AppSearchBar.kt
+++ b/app/src/main/java/com/talauncher/ui/components/AppSearchBar.kt
@@ -1,0 +1,79 @@
+package com.talauncher.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardActions
+import androidx.compose.ui.text.input.KeyboardOptions
+import com.talauncher.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppSearchBar(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholderText: String? = null,
+    onClear: () -> Unit = { onValueChange("") },
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    focusRequester: FocusRequester? = null,
+    colors: TextFieldColors = OutlinedTextFieldDefaults.colors(),
+    shape: Shape = OutlinedTextFieldDefaults.shape,
+    additionalTrailingContent: @Composable RowScope.() -> Unit = {}
+) {
+    val resolvedPlaceholder = placeholderText ?: stringResource(R.string.search_apps)
+    val searchContentDescription = stringResource(R.string.search_icon_content_description)
+    val clearContentDescription = stringResource(R.string.clear_search_content_description)
+
+    val focusModifier = focusRequester?.let { Modifier.focusRequester(it) } ?: Modifier
+
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier.then(focusModifier),
+        placeholder = {
+            Text(text = resolvedPlaceholder)
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = searchContentDescription
+            )
+        },
+        trailingIcon = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                additionalTrailingContent()
+                if (value.isNotEmpty()) {
+                    IconButton(onClick = onClear) {
+                        Icon(
+                            imageVector = Icons.Default.Clear,
+                            contentDescription = clearContentDescription
+                        )
+                    }
+                }
+            }
+        },
+        singleLine = true,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        colors = colors,
+        shape = shape
+    )
+}

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
@@ -4,9 +4,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -16,6 +13,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.talauncher.ui.components.AppSearchBar
 import com.talauncher.ui.insights.InsightsScreen
 import com.talauncher.ui.insights.InsightsViewModel
 import com.talauncher.utils.UsageStatsHelper
@@ -262,7 +260,6 @@ fun SettingItem(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppSelectionTab(
     title: String,
@@ -282,28 +279,11 @@ fun AppSelectionTab(
             modifier = Modifier.padding(bottom = 16.dp)
         )
 
-        OutlinedTextField(
+        AppSearchBar(
             value = searchQuery,
             onValueChange = onSearchQueryChange,
             modifier = Modifier.fillMaxWidth(),
-            placeholder = { Text("Search apps...") },
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Default.Search,
-                    contentDescription = "Search"
-                )
-            },
-            trailingIcon = {
-                if (searchQuery.isNotEmpty()) {
-                    IconButton(onClick = { onSearchQueryChange("") }) {
-                        Icon(
-                            imageVector = Icons.Default.Clear,
-                            contentDescription = "Clear"
-                        )
-                    }
-                }
-            },
-            singleLine = true,
+            onClear = { onSearchQueryChange("") },
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search)
         )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="essential_apps">Essential Apps</string>
     <string name="distracting_apps">Distracting Apps</string>
     <string name="search_apps">Search apps...</string>
+    <string name="search_icon_content_description">Search</string>
+    <string name="clear_search_content_description">Clear search query</string>
     <string name="time_spent_today">Time spent today</string>
     <string name="enable_focus_mode">Enable Focus Mode</string>
     <string name="disable_focus_mode">Disable Focus Mode</string>


### PR DESCRIPTION
## Summary
- extract a reusable `AppSearchBar` composable that matches the main screen search styling
- switch the all apps drawer and settings screens to use the shared search bar while keeping app management actions intact
- add shared string resources for search accessibility text

## Testing
- ./gradlew -Dorg.gradle.java.home=$JAVA_HOME --console=plain lint *(fails: Android SDK is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccfb1f796c8321bd17b5a7da4105cf