### PR TITLE
Align contact action icon colors

### DIFF
--- a/app/src/main/java/com/talauncher/ui/components/ContactItem.kt
+++ b/app/src/main/java/com/talauncher/ui/components/ContactItem.kt
@@ -115,7 +115,7 @@ fun ContactItem(
                         Icon(
                             imageVector = Icons.Default.Send,
                             contentDescription = "WhatsApp",
-                            tint = MaterialTheme.colorScheme.primary
+                            tint = PrimerGreen
                         )
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure the WhatsApp action icon in contact items uses the same PrimerGreen tint as the other actions for visual consistency

## Testing
- `./gradlew test` *(fails: org.gradle.java.home points to a Windows-only JDK path)*

------
https://chatgpt.com/codex/tasks/task_e_68ccffd8eed483218da22539614e3dd7