### PR TITLE
Ensure app drawer refresh runs once per resume

### DIFF
--- a/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerScreen.kt
@@ -52,8 +52,9 @@ import com.talauncher.ui.components.GoogleSearchItem
 import com.talauncher.ui.components.MathChallengeDialog
 import com.talauncher.ui.components.TimeLimitDialog
 import com.talauncher.ui.theme.*
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.text.Collator
 import java.util.Locale
@@ -78,6 +79,7 @@ fun AppDrawerScreen(
     LaunchedEffect(lifecycleOwner) {
         lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
             viewModel.refreshApps()
+            awaitCancellation()
         }
     }
 


### PR DESCRIPTION
## Summary
- keep the app drawer refresh running for the full RESUMED lifecycle state by awaiting cancellation inside repeatOnLifecycle
- add the awaitCancellation import required for the suspend call

## Testing
- ./gradlew test *(fails: Value 'C:\Program Files\Java\jdk-24' given for org.gradle.java.home Gradle property is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68d184049ec883219eebb2c995f04a50