### PR TITLE
Refine distracting app time limits and prompts

### DIFF
--- a/app/src/main/java/com/talauncher/data/database/AppDao.kt
+++ b/app/src/main/java/com/talauncher/data/database/AppDao.kt
@@ -45,6 +45,9 @@ interface AppDao {
     @Query("UPDATE app_info SET isDistracting = :isDistracting WHERE packageName = :packageName")
     suspend fun updateDistractingStatus(packageName: String, isDistracting: Boolean)
 
+    @Query("UPDATE app_info SET timeLimitMinutes = :timeLimit WHERE packageName = :packageName")
+    suspend fun updateTimeLimit(packageName: String, timeLimit: Int?)
+
     @Query("SELECT MAX(pinnedOrder) FROM app_info WHERE isPinned = 1")
     suspend fun getMaxPinnedOrder(): Int?
 

--- a/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
+++ b/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
@@ -12,7 +12,7 @@ import com.talauncher.data.model.LauncherSettings
 
 @Database(
     entities = [AppInfo::class, LauncherSettings::class, AppSession::class],
-    version = 10,
+    version = 11,
     exportSchema = false
 )
 abstract class LauncherDatabase : RoomDatabase() {
@@ -157,6 +157,17 @@ abstract class LauncherDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE launcher_settings ADD COLUMN defaultTimeLimitMinutes INTEGER NOT NULL DEFAULT 30"
+                )
+                database.execSQL(
+                    "ALTER TABLE app_info ADD COLUMN timeLimitMinutes INTEGER"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): LauncherDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -172,7 +183,8 @@ abstract class LauncherDatabase : RoomDatabase() {
                     MIGRATION_6_7,
                     MIGRATION_7_8,
                     MIGRATION_8_9,
-                    MIGRATION_9_10
+                    MIGRATION_9_10,
+                    MIGRATION_10_11
                 ).build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/talauncher/data/model/AppInfo.kt
+++ b/app/src/main/java/com/talauncher/data/model/AppInfo.kt
@@ -10,7 +10,8 @@ data class AppInfo(
     val isPinned: Boolean = false,
     val isHidden: Boolean = false,
     val pinnedOrder: Int = 0,
-    val isDistracting: Boolean = false
+    val isDistracting: Boolean = false,
+    val timeLimitMinutes: Int? = null
 )
 
 data class InstalledApp(

--- a/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
+++ b/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
@@ -17,6 +17,7 @@ data class LauncherSettings(
     val mathDifficulty: String = "easy", // "easy", "medium", "hard"
     val sessionExpiryCountdownSeconds: Int = 5, // Number of seconds to block the app before prompting for action
     val recentAppsLimit: Int = 10, // Number of recent apps to show in insights
+    val defaultTimeLimitMinutes: Int = 30, // Default time limit applied to distracting apps
     val showPhoneAction: Boolean = true,
     val showMessageAction: Boolean = true,
     val showWhatsAppAction: Boolean = true,

--- a/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
@@ -49,6 +49,12 @@ class SettingsRepository(private val settingsDao: SettingsDao) {
         updateSettings(settings.copy(sessionExpiryCountdownSeconds = seconds.coerceIn(0, 30)))
     }
 
+    suspend fun updateDefaultTimeLimit(minutes: Int) {
+        val settings = getSettingsSync()
+        val sanitized = minutes.coerceIn(5, 480)
+        updateSettings(settings.copy(defaultTimeLimitMinutes = sanitized))
+    }
+
     suspend fun updateBuildInfo(
         commitHash: String?,
         commitMessage: String?,

--- a/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerScreen.kt
@@ -53,9 +53,7 @@ import com.talauncher.ui.components.MathChallengeDialog
 import com.talauncher.ui.components.TimeLimitDialog
 import com.talauncher.ui.theme.*
 import kotlinx.coroutines.awaitCancellation
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.text.Collator
 import java.util.Locale
 import kotlin.math.max
@@ -576,24 +574,16 @@ fun AppDrawerScreen(
         if (uiState.showTimeLimitDialog) {
             run {
                 val selectedPackage = uiState.selectedAppForTimeLimit ?: return@run
-                var appName by remember(selectedPackage) { mutableStateOf(selectedPackage) }
-
-                LaunchedEffect(selectedPackage) {
-                    appName = withContext(Dispatchers.IO) {
-                        try {
-                            val packageManager = context.packageManager
-                            val appInfo = packageManager.getApplicationInfo(selectedPackage, 0)
-                            packageManager.getApplicationLabel(appInfo).toString()
-                        } catch (e: Exception) {
-                            selectedPackage
-                        }
-                    }
-                }
-
                 TimeLimitDialog(
-                    appName = appName,
-                    onConfirm = { durationMinutes ->
-                        viewModel.launchAppWithTimeLimit(selectedPackage, durationMinutes)
+                    appName = uiState.timeLimitDialogAppName ?: selectedPackage,
+                    usageMinutes = uiState.timeLimitDialogUsageMinutes,
+                    timeLimitMinutes = uiState.timeLimitDialogTimeLimitMinutes,
+                    isUsingDefaultLimit = uiState.timeLimitDialogUsesDefaultLimit,
+                    onConfirm = {
+                        viewModel.launchAppWithTimeLimit(
+                            selectedPackage,
+                            uiState.timeLimitDialogTimeLimitMinutes
+                        )
                     },
                     onDismiss = { viewModel.dismissTimeLimitDialog() }
                 )

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -320,24 +320,16 @@ fun HomeScreen(
         if (uiState.showTimeLimitDialog) {
             run {
                 val selectedPackage = uiState.selectedAppForTimeLimit ?: return@run
-                var appName by remember(selectedPackage) { mutableStateOf(selectedPackage) }
-
-                LaunchedEffect(selectedPackage) {
-                    appName = withContext(Dispatchers.IO) {
-                        try {
-                            val packageManager = context.packageManager
-                            val appInfo = packageManager.getApplicationInfo(selectedPackage, 0)
-                            packageManager.getApplicationLabel(appInfo).toString()
-                        } catch (e: Exception) {
-                            selectedPackage
-                        }
-                    }
-                }
-
                 TimeLimitDialog(
-                    appName = appName,
-                    onConfirm = { durationMinutes ->
-                        viewModel.launchAppWithTimeLimit(selectedPackage, durationMinutes)
+                    appName = uiState.timeLimitDialogAppName ?: selectedPackage,
+                    usageMinutes = uiState.timeLimitDialogUsageMinutes,
+                    timeLimitMinutes = uiState.timeLimitDialogTimeLimitMinutes,
+                    isUsingDefaultLimit = uiState.timeLimitDialogUsesDefaultLimit,
+                    onConfirm = {
+                        viewModel.launchAppWithTimeLimit(
+                            selectedPackage,
+                            uiState.timeLimitDialogTimeLimitMinutes
+                        )
                     },
                     onDismiss = { viewModel.dismissTimeLimitDialog() }
                 )

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
@@ -55,6 +55,7 @@ class SettingsViewModel(
                     mathDifficulty = settings?.mathDifficulty ?: "easy",
                     sessionExpiryCountdownSeconds = settings?.sessionExpiryCountdownSeconds ?: 5,
                     recentAppsLimit = settings?.recentAppsLimit ?: 5,
+                    defaultTimeLimitMinutes = settings?.defaultTimeLimitMinutes ?: 30,
                     showPhoneAction = settings?.showPhoneAction ?: true,
                     showMessageAction = settings?.showMessageAction ?: true,
                     showWhatsAppAction = settings?.showWhatsAppAction ?: true,
@@ -123,6 +124,12 @@ class SettingsViewModel(
         }
     }
 
+    fun updateDefaultTimeLimit(minutes: Int) {
+        viewModelScope.launch {
+            settingsRepository.updateDefaultTimeLimit(minutes)
+        }
+    }
+
     fun updateMathDifficulty(difficulty: String) {
         viewModelScope.launch {
             settingsRepository.updateMathDifficulty(difficulty)
@@ -138,6 +145,12 @@ class SettingsViewModel(
     fun updateRecentAppsLimit(limit: Int) {
         viewModelScope.launch {
             settingsRepository.updateRecentAppsLimit(limit)
+        }
+    }
+
+    fun updateAppTimeLimit(packageName: String, minutes: Int?) {
+        viewModelScope.launch {
+            appRepository.updateAppTimeLimit(packageName, minutes)
         }
     }
 
@@ -259,6 +272,7 @@ data class SettingsUiState(
     val mathDifficulty: String = "easy",
     val sessionExpiryCountdownSeconds: Int = 5,
     val recentAppsLimit: Int = 5,
+    val defaultTimeLimitMinutes: Int = 30,
     val isLoading: Boolean = false,
     val searchQuery: String = "",
     val showPhoneAction: Boolean = false,


### PR DESCRIPTION
## Summary
- store optional per-app time limit overrides and a configurable default in settings with accompanying Room migration
- expand the Distracting Apps settings tab with default limit controls, stopwatch editing affordances, and supporting viewmodel logic
- replace the time limit dialog with a usage-aware confirmation that shows daily minutes and the applied limit across home and drawer flows

## Testing
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME test --console=plain` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c6271f2c8321963964a9a314a972