### PR TITLE
Add onboarding gating Espresso test coverage

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -1,0 +1,64 @@
+# Espresso UI Test Plan
+
+This document outlines the recommended Espresso UI test coverage for TALauncher. Each flow focuses on verifying key user journeys and edge cases across onboarding, the launcher experience, personalization, and distraction-management features.
+
+## 1. Onboarding to Launcher Transition
+- Complete onboarding and verify that the activity transitions to the launcher UI.
+- Ensure `MainViewModel` persists the completion state so returning to the app skips onboarding.
+- Resume the activity from the background and confirm the pager snaps back to the home page.
+
+## 2. Pager Navigation and Back Handling
+- Validate the horizontal pager defaults to the home screen.
+- Swipe to the settings page and confirm navigation indicators update.
+- Launch an app and observe that the pager animates to the rightmost page.
+- Use the system back button from various pages and ensure the custom handler always returns to the home page instead of exiting.
+
+## 3. Home Search and Unified Results
+- Enter queries in the search field to surface app and contact results.
+- Trigger Google-search actions and confirm appropriate intents fire.
+- Exercise contact action buttons (call, message, WhatsApp, open contact) and verify success flows and permission gating prompts when contacts access is missing.
+
+## 4. App List Browsing
+- Inspect the recent-apps header and ensure it populates correctly.
+- Scroll through the full app list, testing alphabet index scrubbing behaviour.
+- Long-press list entries to open the action dialog and validate hide, app info, and uninstall flows.
+
+## 5. Launching Distracting Apps
+- Launch apps flagged as distracting to trigger time-limit prompts or friction dialogs.
+- Provide reasons or custom durations when prompted and confirm the selected values apply.
+- Cancel prompts and ensure overlays dismiss cleanly without side effects.
+
+## 6. Session Expiry Lifecycle
+- Simulate session expiry to activate countdown overlays and decision dialogs.
+- Verify extend and close choices behave correctly, including math-challenge fallback scenarios.
+- Follow the overlay-permission request path and confirm the experience recovers when permission is granted or denied.
+
+## 7. Home Status Elements
+- Toggle time/date and weather options in settings to confirm UI updates on the home screen.
+- Validate clock and weather widgets respond to state changes and display error messaging when location permission is absent.
+
+## 8. Settings Tab Navigation
+- Navigate between General, UI & Theme, Distracting Apps, and Usage Insights tabs.
+- Check that tab selection state updates accurately and search fields reset when leaving the app list tab.
+- Launch the embedded Insights screen and verify view-model wiring.
+
+## 9. General Settings Controls
+- Toggle and adjust controls for time-limit prompts, math challenges, countdown durations, recent-apps limits, contact actions, weather display, temperature units, and build info visibility.
+- Confirm persisted preferences reflect UI changes and that invalid inputs are rejected.
+
+## 10. UI and Theme Customization
+- Select palette chips, toggle wallpaper, and adjust blur/opacity sliders to ensure immediate visual feedback.
+- Test custom wallpaper picker and clear actions, along with glassmorphism, UI density, and animation switches.
+
+## 11. Distracting App Curation
+- Use the search/filter field to locate apps and adjust the default time-limit slider.
+- Select and deselect apps from the distracting list, confirming UI and data updates.
+- Edit per-app overrides via the time-limit dialog and validate input handling.
+
+## 12. Usage Insights Permission and Data
+- Walk through the usage-access permission workflow and verify messaging for granted/denied states.
+- Trigger data refresh and observe populated and empty usage list presentations in the embedded Insights screen.
+
+---
+
+These scenarios provide broad coverage of TALauncher’s critical user journeys and edge cases. Each test should assert on both visual state and underlying behaviour (view-model state, intents, and permissions) to ensure regressions are caught early.

--- a/app/src/androidTest/java/com/talauncher/OnboardingGatingFlowTest.kt
+++ b/app/src/androidTest/java/com/talauncher/OnboardingGatingFlowTest.kt
@@ -1,0 +1,201 @@
+package com.talauncher
+
+import android.app.Activity
+import android.content.Context
+import android.os.Build
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.talauncher.data.database.SettingsDao
+import com.talauncher.data.model.LauncherSettings
+import com.talauncher.data.repository.SettingsRepository
+import com.talauncher.ui.onboarding.OnboardingScreen
+import com.talauncher.ui.onboarding.OnboardingViewModel
+import com.talauncher.ui.theme.TALauncherTheme
+import com.talauncher.utils.PermissionState
+import com.talauncher.utils.PermissionType
+import com.talauncher.utils.PermissionsHelper
+import com.talauncher.utils.UsageStatsHelper
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class OnboardingGatingFlowTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun onboardingGatingFlow_requiresCompletingAllStepsBeforeSuccessCard() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val notificationsInitiallyGranted = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
+        val usageStatsHelper = FakeUsageStatsHelper(context)
+        val permissionsHelper = FakePermissionsHelper(context, notificationsInitiallyGranted).apply {
+            onDefaultLauncherRequest = { usageStatsHelper.setDefaultLauncher(true) }
+        }
+        val settingsRepository = SettingsRepository(FakeSettingsDao())
+        val onboardingViewModel = OnboardingViewModel(settingsRepository)
+
+        var completionCount = 0
+
+        composeTestRule.setContent {
+            TALauncherTheme {
+                OnboardingScreen(
+                    onOnboardingComplete = { completionCount++ },
+                    viewModel = onboardingViewModel,
+                    permissionsHelper = permissionsHelper,
+                    usageStatsHelper = usageStatsHelper
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("onboarding_success_card").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("onboarding_incomplete_message").assertExists()
+
+        composeTestRule.onNodeWithTag("onboarding_step_default_launcher_button").assertIsEnabled()
+        composeTestRule.onNodeWithTag("onboarding_step_usage_stats_button").assertIsEnabled()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            composeTestRule.onNodeWithTag("onboarding_step_notifications_button").assertIsEnabled()
+        }
+        composeTestRule.onNodeWithTag("onboarding_step_overlay_button").assertIsEnabled()
+
+        composeTestRule.onNodeWithTag("onboarding_step_usage_stats_button").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("onboarding_step_usage_stats_button").assertIsNotEnabled()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            composeTestRule.onNodeWithTag("onboarding_step_notifications_button").performClick()
+            composeTestRule.waitForIdle()
+            composeTestRule.onNodeWithTag("onboarding_step_notifications_button").assertIsNotEnabled()
+        }
+
+        composeTestRule.onNodeWithTag("onboarding_step_overlay_button").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("onboarding_step_overlay_button").assertIsNotEnabled()
+
+        composeTestRule.onNodeWithTag("onboarding_success_card").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("onboarding_incomplete_message").assertExists()
+        assertEquals(0, completionCount)
+
+        composeTestRule.onNodeWithTag("onboarding_step_default_launcher_button").performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            usageStatsHelper.setDefaultLauncher(true)
+            permissionsHelper.setOverlayGranted(false)
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("onboarding_success_card").assertDoesNotExist()
+
+        composeTestRule.runOnIdle {
+            permissionsHelper.setOverlayGranted(true)
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag("onboarding_success_card").assertExists()
+        composeTestRule.onNodeWithTag("onboarding_incomplete_message").assertDoesNotExist()
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) { completionCount == 1 }
+        assertEquals(1, completionCount)
+    }
+}
+
+private class FakePermissionsHelper(
+    context: Context,
+    notificationsInitiallyGranted: Boolean
+) : PermissionsHelper(context) {
+
+    var onDefaultLauncherRequest: (() -> Unit)? = null
+
+    private var backingState = PermissionState(
+        hasUsageStats = false,
+        hasSystemAlertWindow = false,
+        hasNotifications = notificationsInitiallyGranted,
+        hasContacts = false,
+        hasCallPhone = false,
+        hasLocation = false
+    )
+
+    init {
+        overridePermissionState(backingState)
+    }
+
+    override fun checkAllPermissions() {
+        overridePermissionState(backingState)
+    }
+
+    override fun requestPermission(activity: Activity, type: PermissionType) {
+        when (type) {
+            PermissionType.USAGE_STATS -> setUsageStatsGranted(true)
+            PermissionType.SYSTEM_ALERT_WINDOW -> setOverlayGranted(true)
+            PermissionType.NOTIFICATIONS -> setNotificationsGranted(true)
+            PermissionType.DEFAULT_LAUNCHER -> {
+                onDefaultLauncherRequest?.invoke()
+                val transientState = backingState.copy(
+                    hasSystemAlertWindow = !backingState.hasSystemAlertWindow
+                )
+                overridePermissionState(transientState)
+                overridePermissionState(backingState)
+            }
+            else -> Unit
+        }
+    }
+
+    fun setUsageStatsGranted(granted: Boolean) {
+        updateState { it.copy(hasUsageStats = granted) }
+    }
+
+    fun setNotificationsGranted(granted: Boolean) {
+        updateState { it.copy(hasNotifications = granted) }
+    }
+
+    fun setOverlayGranted(granted: Boolean) {
+        updateState { it.copy(hasSystemAlertWindow = granted) }
+    }
+
+    private fun updateState(transform: (PermissionState) -> PermissionState) {
+        backingState = transform(backingState)
+        overridePermissionState(backingState)
+    }
+}
+
+private class FakeUsageStatsHelper(context: Context) : UsageStatsHelper(context) {
+    private var isDefaultLauncher = false
+
+    fun setDefaultLauncher(value: Boolean) {
+        isDefaultLauncher = value
+        overrideIsDefaultLauncher(value)
+    }
+
+    override fun isDefaultLauncher(): Boolean = isDefaultLauncher
+}
+
+private class FakeSettingsDao : SettingsDao {
+    private var settings: LauncherSettings = LauncherSettings()
+    private val state = MutableStateFlow<LauncherSettings?>(settings)
+
+    override fun getSettings(): Flow<LauncherSettings?> = state.asStateFlow()
+
+    override suspend fun getSettingsSync(): LauncherSettings? = settings
+
+    override suspend fun insertSettings(settings: LauncherSettings) {
+        this.settings = settings
+        state.value = settings
+    }
+
+    override suspend fun updateSettings(settings: LauncherSettings) {
+        this.settings = settings
+        state.value = settings
+    }
+}

--- a/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
+++ b/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
@@ -10,6 +10,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Process
 import android.provider.Settings
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -38,7 +39,7 @@ enum class PermissionType {
     LOCATION
 }
 
-class PermissionsHelper(
+open class PermissionsHelper(
     private val context: Context
 ) {
 
@@ -49,7 +50,7 @@ class PermissionsHelper(
         checkAllPermissions()
     }
 
-    fun checkAllPermissions() {
+    open fun checkAllPermissions() {
         _permissionState.value = PermissionState(
             hasUsageStats = hasUsageStatsPermission(),
             hasSystemAlertWindow = hasSystemAlertWindowPermission(),
@@ -60,7 +61,7 @@ class PermissionsHelper(
         )
     }
 
-    fun requestPermission(activity: Activity, type: PermissionType) {
+    open fun requestPermission(activity: Activity, type: PermissionType) {
         when (type) {
             PermissionType.USAGE_STATS -> openUsageAccessSettings()
             PermissionType.SYSTEM_ALERT_WINDOW -> requestSystemAlertWindowPermission()
@@ -70,6 +71,11 @@ class PermissionsHelper(
             PermissionType.DEFAULT_LAUNCHER -> openDefaultLauncherSettings()
             PermissionType.LOCATION -> requestLocationPermission(activity)
         }
+    }
+
+    @VisibleForTesting
+    fun overridePermissionState(permissionState: PermissionState) {
+        _permissionState.value = permissionState
     }
 
     fun handlePermissionResult(


### PR DESCRIPTION
## Summary
- add a dedicated Compose-based Espresso test that exercises onboarding gating and success criteria
- expose testing hooks on PermissionsHelper and UsageStatsHelper to control onboarding state
- tag onboarding UI elements for deterministic assertions and update the test plan accordingly

## Testing
- `./gradlew :app:assembleDebug` *(fails: Value 'C:\\Program Files\\Java\\jdk-24' given for org.gradle.java.home Gradle property is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68d68eb2608083218a36017675b0bf29