### PR TITLE
Add shared padding helper for settings tabs

### DIFF
--- a/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -19,9 +20,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -242,6 +245,30 @@ fun SettingsScreen(
 }
 
 @Composable
+private fun SettingsLazyColumn(
+    modifier: Modifier = Modifier,
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(12.dp),
+    extraBottomPadding: Dp = 24.dp,
+    content: LazyListScope.() -> Unit
+) {
+    val layoutDirection = LocalLayoutDirection.current
+    val navigationBarsPadding = WindowInsets.navigationBars.asPaddingValues()
+    val contentPadding = PaddingValues(
+        start = navigationBarsPadding.calculateStartPadding(layoutDirection),
+        top = navigationBarsPadding.calculateTopPadding(),
+        end = navigationBarsPadding.calculateEndPadding(layoutDirection),
+        bottom = navigationBarsPadding.calculateBottomPadding() + extraBottomPadding
+    )
+
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = contentPadding,
+        verticalArrangement = verticalArrangement,
+        content = content
+    )
+}
+
+@Composable
 fun UIThemeSettings(
     backgroundColor: String,
     onUpdateBackgroundColor: (String) -> Unit,
@@ -263,9 +290,7 @@ fun UIThemeSettings(
     enableAnimations: Boolean,
     onToggleAnimations: (Boolean) -> Unit
 ) {
-    LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
+    SettingsLazyColumn {
         item {
             Card(
                 modifier = Modifier.fillMaxWidth(),
@@ -580,9 +605,7 @@ fun GeneralSettings(
     buildBranch: String?,
     buildTime: String?
 ) {
-    LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
+    SettingsLazyColumn {
         item {
             Card(
                 modifier = Modifier.fillMaxWidth(),
@@ -1138,8 +1161,9 @@ fun AppSelectionTab(
                 CircularProgressIndicator()
             }
         } else {
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+            SettingsLazyColumn(
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                extraBottomPadding = 16.dp
             ) {
                 items(apps) { app ->
                     val info = timeLimitInfoProvider?.invoke(app)


### PR DESCRIPTION
## Summary
- add a reusable `SettingsLazyColumn` that adds navigation bar padding to tab content
- update the general, UI/theme, and distracting apps tabs to use the shared list helper so items clear the navbar

## Testing
- ./gradlew :app:lint *(fails: Value 'C:\\Program Files\\Java\\jdk-24' given for org.gradle.java.home Gradle property is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b459b73c8321a73e4be84341e4e1