### PR TITLE
Use chat icon for WhatsApp action

### DIFF
--- a/app/src/main/java/com/talauncher/ui/components/ContactItem.kt
+++ b/app/src/main/java/com/talauncher/ui/components/ContactItem.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Call
+import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.Email
-import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -112,7 +112,7 @@ fun ContactItem(
                 if (showWhatsAppAction) {
                     IconButton(onClick = onWhatsApp) {
                         Icon(
-                            imageVector = Icons.Default.Phone,
+                            imageVector = Icons.Default.Chat,
                             contentDescription = "WhatsApp",
                             tint = PrimerGreen
                         )


### PR DESCRIPTION
## Summary
- replace the WhatsApp action icon with the material chat icon so it is distinct from the phone action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80ec991c8832180dbe03c8457368b