### PR TITLE
Move location lookup off main thread

### DIFF
--- a/app/src/main/java/com/talauncher/service/WeatherService.kt
+++ b/app/src/main/java/com/talauncher/service/WeatherService.kt
@@ -103,10 +103,10 @@ class WeatherService(private val context: Context) {
         }
     }
 
-    fun getCurrentLocation(): Pair<Double, Double>? {
+    suspend fun getCurrentLocation(): Pair<Double, Double>? = withContext(Dispatchers.IO) {
         val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
 
-        return try {
+        try {
             val providers = locationManager.getProviders(true)
             var bestLocation: Location? = null
 

--- a/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
@@ -1169,7 +1169,9 @@ class HomeViewModel(
                 } else {
                     // Try to get current location
                     if (resolvedPermissionsHelper?.hasLocationPermission() == true) {
-                        weatherService.getCurrentLocation()
+                        withContext(Dispatchers.IO) {
+                            weatherService.getCurrentLocation()
+                        }
                     } else {
                         null
                     }


### PR DESCRIPTION
## Summary
- wrap the WeatherService location lookup inside an IO-dispatched suspend function so binder calls run off the main thread
- update HomeViewModel to await the new suspend API from an IO context when fetching the current location

## Testing
- ./gradlew test *(fails: SDK location not found in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d82d6b526c8321b4c1ecebe3e75389