### PR TITLE
Refine custom color palette updates

### DIFF
--- a/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
@@ -131,19 +131,21 @@ class SettingsRepository(private val settingsDao: SettingsDao) {
         updateSettings(settings.copy(colorPalette = palette))
     }
 
-    suspend fun updateCustomColorOption(customColorOption: String?) {
+    suspend fun setCustomPalette(
+        palette: ColorPaletteOption,
+        customColorOption: String?,
+        customPrimaryColor: String?,
+        customSecondaryColor: String?
+    ) {
         val settings = getSettingsSync()
-        updateSettings(settings.copy(customColorOption = customColorOption))
-    }
-
-    suspend fun updateCustomPrimaryColor(customPrimaryColor: String?) {
-        val settings = getSettingsSync()
-        updateSettings(settings.copy(customPrimaryColor = customPrimaryColor))
-    }
-
-    suspend fun updateCustomSecondaryColor(customSecondaryColor: String?) {
-        val settings = getSettingsSync()
-        updateSettings(settings.copy(customSecondaryColor = customSecondaryColor))
+        updateSettings(
+            settings.copy(
+                colorPalette = palette,
+                customColorOption = customColorOption,
+                customPrimaryColor = customPrimaryColor,
+                customSecondaryColor = customSecondaryColor
+            )
+        )
     }
 
     suspend fun updateThemeMode(mode: ThemeModeOption) {

--- a/app/src/main/java/com/talauncher/ui/components/ThemeComponents.kt
+++ b/app/src/main/java/com/talauncher/ui/components/ThemeComponents.kt
@@ -246,7 +246,6 @@ fun ColorPaletteSelector(
         currentCustomColor = currentCustomColor,
         onColorSelected = { colorName ->
             onCustomColorSelected(colorName)
-            onPaletteSelected(ColorPaletteOption.CUSTOM)
             showCustomColorPicker = false
         },
         onDismiss = { showCustomColorPicker = false }

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
@@ -186,25 +186,55 @@ class SettingsViewModel(
 
     fun updateColorPalette(palette: ColorPaletteOption) {
         viewModelScope.launch {
-            settingsRepository.updateColorPalette(palette)
+            if (palette == ColorPaletteOption.CUSTOM) {
+                settingsRepository.setCustomPalette(
+                    palette = ColorPaletteOption.CUSTOM,
+                    customColorOption = _uiState.value.customColorOption,
+                    customPrimaryColor = _uiState.value.customPrimaryColor,
+                    customSecondaryColor = _uiState.value.customSecondaryColor
+                )
+            } else {
+                settingsRepository.updateColorPalette(palette)
+            }
         }
     }
 
     fun updateCustomColorOption(colorOption: String) {
-        viewModelScope.launch {
-            settingsRepository.updateCustomColorOption(colorOption)
-        }
+        setCustomPalette(
+            customColorOption = colorOption,
+            customPrimaryColor = _uiState.value.customPrimaryColor,
+            customSecondaryColor = _uiState.value.customSecondaryColor
+        )
     }
 
     fun updateCustomPrimaryColor(primaryColor: String?) {
-        viewModelScope.launch {
-            settingsRepository.updateCustomPrimaryColor(primaryColor)
-        }
+        setCustomPalette(
+            customColorOption = _uiState.value.customColorOption,
+            customPrimaryColor = primaryColor,
+            customSecondaryColor = _uiState.value.customSecondaryColor
+        )
     }
 
     fun updateCustomSecondaryColor(secondaryColor: String?) {
+        setCustomPalette(
+            customColorOption = _uiState.value.customColorOption,
+            customPrimaryColor = _uiState.value.customPrimaryColor,
+            customSecondaryColor = secondaryColor
+        )
+    }
+
+    private fun setCustomPalette(
+        customColorOption: String?,
+        customPrimaryColor: String?,
+        customSecondaryColor: String?
+    ) {
         viewModelScope.launch {
-            settingsRepository.updateCustomSecondaryColor(secondaryColor)
+            settingsRepository.setCustomPalette(
+                palette = ColorPaletteOption.CUSTOM,
+                customColorOption = customColorOption,
+                customPrimaryColor = customPrimaryColor,
+                customSecondaryColor = customSecondaryColor
+            )
         }
     }
 

--- a/app/src/test/java/com/talauncher/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/talauncher/SettingsRepositoryTest.kt
@@ -110,6 +110,28 @@ class SettingsRepositoryTest {
     }
 
     @Test
+    fun `setCustomPalette updates palette and custom colors together`() = runTest {
+        println("Running setCustomPalette updates palette and custom colors together test")
+        whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
+
+        repository.setCustomPalette(
+            palette = ColorPaletteOption.CUSTOM,
+            customColorOption = "Purple",
+            customPrimaryColor = "#123456",
+            customSecondaryColor = "#654321"
+        )
+
+        verify(settingsDao).updateSettings(
+            check {
+                assertEquals(ColorPaletteOption.CUSTOM, it.colorPalette)
+                assertEquals("Purple", it.customColorOption)
+                assertEquals("#123456", it.customPrimaryColor)
+                assertEquals("#654321", it.customSecondaryColor)
+            }
+        )
+    }
+
+    @Test
     fun `updateWallpaperBlurAmount clamps value`() = runTest {
         println("Running updateWallpaperBlurAmount clamps value test")
         whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)


### PR DESCRIPTION
## Summary
- add a `setCustomPalette` helper in `SettingsRepository` to write all custom color fields together
- route `SettingsViewModel` and the `ColorPaletteSelector` through the combined call so custom selections update once
- extend the repository unit tests to cover the consolidated custom palette update

## Testing
- ./gradlew test *(fails: required Java 17 toolchain is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da33ee1bd88321978424fa77e7d70b