### PR TITLE
Add contacts permission to onboarding flow

### DIFF
--- a/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -151,6 +152,22 @@ fun OnboardingScreen(
             buttonTestTag = "onboarding_step_overlay_button",
             onButtonClick = {
                 permissionsHelper.requestPermission(context as Activity, PermissionType.SYSTEM_ALERT_WINDOW)
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Contacts Permission
+        OnboardingStepCard(
+            modifier = Modifier.testTag("onboarding_step_contacts"),
+            icon = Icons.Default.Person,
+            title = "Contacts Permission",
+            description = "Required to access your contact list for calling essentials",
+            isCompleted = permissionState.hasContacts,
+            buttonText = if (permissionState.hasContacts) "Completed" else "Grant Permission",
+            buttonTestTag = "onboarding_step_contacts_button",
+            onButtonClick = {
+                permissionsHelper.requestPermission(context as Activity, PermissionType.CONTACTS)
             }
         )
 

--- a/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
+++ b/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
@@ -26,7 +26,12 @@ data class PermissionState(
     val hasLocation: Boolean = false
 ) {
     val allOnboardingPermissionsGranted: Boolean
-        get() = hasUsageStats && hasSystemAlertWindow && hasNotifications && hasLocation
+        get() =
+            hasUsageStats &&
+                hasSystemAlertWindow &&
+                hasNotifications &&
+                hasContacts &&
+                hasLocation
 }
 
 enum class PermissionType {

--- a/uitests/src/androidTest/java/com/talauncher/OnboardingGatingFlowTest.kt
+++ b/uitests/src/androidTest/java/com/talauncher/OnboardingGatingFlowTest.kt
@@ -74,6 +74,8 @@ class OnboardingGatingFlowTest {
             composeTestRule.onNodeWithTag("onboarding_step_notifications_button").assertIsEnabled()
         }
         composeTestRule.onNodeWithTag("onboarding_step_overlay_button").assertIsEnabled()
+        composeTestRule.onNodeWithTag("onboarding_step_contacts_button").assertIsEnabled()
+        composeTestRule.onNodeWithTag("onboarding_step_location_button").assertIsEnabled()
 
         // Grant usage stats permission
         Log.d("OnboardingGatingFlowTest", "Granting usage stats permission")
@@ -127,6 +129,34 @@ class OnboardingGatingFlowTest {
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             try {
                 composeTestRule.onNodeWithTag("onboarding_step_overlay_button").assertIsNotEnabled()
+                true
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+
+        // Grant contacts permission
+        composeTestRule.onNodeWithTag("onboarding_step_contacts_button").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            permissionsHelper.permissionState.value.hasContacts
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            try {
+                composeTestRule.onNodeWithTag("onboarding_step_contacts_button").assertIsNotEnabled()
+                true
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+
+        // Grant location permission
+        composeTestRule.onNodeWithTag("onboarding_step_location_button").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            permissionsHelper.permissionState.value.hasLocation
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            try {
+                composeTestRule.onNodeWithTag("onboarding_step_location_button").assertIsNotEnabled()
                 true
             } catch (e: AssertionError) {
                 false
@@ -205,7 +235,9 @@ private class FakePermissionsHelper(
             PermissionType.DEFAULT_LAUNCHER -> {
                 onDefaultLauncherRequest?.invoke()
             }
-            else -> Unit
+            PermissionType.CONTACTS -> setContactsGranted(true)
+            PermissionType.LOCATION -> setLocationGranted(true)
+            PermissionType.CALL_PHONE -> Unit
         }
     }
 
@@ -219,6 +251,14 @@ private class FakePermissionsHelper(
 
     fun setOverlayGranted(granted: Boolean) {
         updateState { it.copy(hasSystemAlertWindow = granted) }
+    }
+
+    fun setContactsGranted(granted: Boolean) {
+        updateState { it.copy(hasContacts = granted) }
+    }
+
+    fun setLocationGranted(granted: Boolean) {
+        updateState { it.copy(hasLocation = granted) }
     }
 
     private fun updateState(transform: (PermissionState) -> PermissionState) {


### PR DESCRIPTION
## Summary
- add the contacts permission card to the onboarding checklist so it is requested with the rest of the required access
- require contacts access for completing onboarding by updating the permission state aggregator
- expand the onboarding gating UI test double to cover contacts and location permissions

## Testing
- ./gradlew test *(fails: Java 17 toolchain is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da3f8fbe00832198e6aca4ca900de9