### PR TITLE
Use instant alphabet index snapping

### DIFF
--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -291,7 +291,7 @@ fun HomeScreen(
                         val entry = uiState.alphabetIndexEntries.find { it.key == activeKey }
                         if (entry != null) {
                             if (entry.key == RECENT_APPS_INDEX_KEY) {
-                                listState.animateScrollToItem(0)
+                                listState.scrollToItem(0)
                             } else {
                                 entry.targetIndex?.let { targetIndex ->
                                     // Adjust index to account for recent apps section
@@ -301,7 +301,7 @@ fun HomeScreen(
                                     } else {
                                         targetIndex
                                     }
-                                    listState.animateScrollToItem(adjustedIndex)
+                                    listState.scrollToItem(adjustedIndex)
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- switch alphabet index scrolling to use snap-to-item behaviour so fast scroll responds immediately

## Testing
- not run (not available in container environment)

------
https://chatgpt.com/codex/tasks/task_e_68da42b617c48321bea64e6d26b9899c