### PR TITLE
Default to compact UI density

### DIFF
--- a/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
+++ b/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
@@ -40,7 +40,7 @@ data class LauncherSettings(
     val themeMode: ThemeModeOption = ThemeModeOption.SYSTEM, // System, Light, or Dark theme
     val wallpaperBlurAmount: Float = 0f, // 0.0 (no blur) to 1.0 (max blur)
     val enableGlassmorphism: Boolean = true, // Enable glass-like translucent effects
-    val uiDensity: UiDensityOption = UiDensityOption.COMFORTABLE,
+    val uiDensity: UiDensityOption = UiDensityOption.COMPACT,
     val cardCornerRadius: Int = 12, // Corner radius for cards in dp (8-24)
     val enableDynamicColors: Boolean = false, // Use Material You dynamic colors when available
     val backgroundOpacity: Float = 1.0f, // Background opacity when wallpaper is shown (0.0-1.0)

--- a/app/src/main/java/com/talauncher/data/model/SettingsOptions.kt
+++ b/app/src/main/java/com/talauncher/data/model/SettingsOptions.kt
@@ -99,7 +99,7 @@ enum class UiDensityOption(val label: String) {
     companion object {
         fun fromStorageValue(value: String?): UiDensityOption {
             val normalized = value?.lowercase(Locale.US)
-            return entries.firstOrNull { it.name.lowercase(Locale.US) == normalized } ?: COMFORTABLE
+            return entries.firstOrNull { it.name.lowercase(Locale.US) == normalized } ?: COMPACT
         }
     }
 }

--- a/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
@@ -246,7 +246,7 @@ class HomeViewModel(
                             wallpaperBlurAmount = settings?.wallpaperBlurAmount ?: 0f,
                             customWallpaperPath = settings?.customWallpaperPath,
                             enableGlassmorphism = settings?.enableGlassmorphism ?: true,
-                            uiDensity = settings?.uiDensity ?: UiDensityOption.COMFORTABLE,
+                            uiDensity = settings?.uiDensity ?: UiDensityOption.COMPACT,
                             enableAnimations = settings?.enableAnimations ?: true,
                             // App drawer functionality moved to home screen
                             recentApps = recentApps,
@@ -1554,7 +1554,7 @@ data class HomeUiState(
     val colorPalette: ColorPaletteOption = ColorPaletteOption.DEFAULT,
     val wallpaperBlurAmount: Float = 0f,
     val enableGlassmorphism: Boolean = true,
-    val uiDensity: UiDensityOption = UiDensityOption.COMFORTABLE,
+    val uiDensity: UiDensityOption = UiDensityOption.COMPACT,
     val enableAnimations: Boolean = true,
     // App drawer functionality moved to home screen
     val recentApps: List<AppInfo> = emptyList(),

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
@@ -80,7 +80,7 @@ class SettingsViewModel(
                     wallpaperBlurAmount = settings?.wallpaperBlurAmount ?: 0f,
                     backgroundOpacity = settings?.backgroundOpacity ?: 1f,
                     enableGlassmorphism = settings?.enableGlassmorphism ?: true,
-                    uiDensity = settings?.uiDensity ?: UiDensityOption.COMFORTABLE,
+                    uiDensity = settings?.uiDensity ?: UiDensityOption.COMPACT,
                     enableAnimations = settings?.enableAnimations ?: true,
                     customWallpaperPath = settings?.customWallpaperPath,
                     availableApps = allInstalledApps,
@@ -356,7 +356,7 @@ data class SettingsUiState(
     val wallpaperBlurAmount: Float = 0f,
     val backgroundOpacity: Float = 1f,
     val enableGlassmorphism: Boolean = true,
-    val uiDensity: UiDensityOption = UiDensityOption.COMFORTABLE,
+    val uiDensity: UiDensityOption = UiDensityOption.COMPACT,
     val enableAnimations: Boolean = true,
     val customWallpaperPath: String? = null
 )

--- a/app/src/main/java/com/talauncher/ui/theme/UiSettings.kt
+++ b/app/src/main/java/com/talauncher/ui/theme/UiSettings.kt
@@ -16,7 +16,7 @@ data class UiSettings(
     val themeMode: ThemeModeOption = ThemeModeOption.SYSTEM,
     val enableGlassmorphism: Boolean = true,
     val enableAnimations: Boolean = true,
-    val uiDensity: UiDensityOption = UiDensityOption.COMFORTABLE,
+    val uiDensity: UiDensityOption = UiDensityOption.COMPACT,
     val showWallpaper: Boolean = false,
     val wallpaperBlurAmount: Float = 0f,
     val backgroundColor: String = "system",
@@ -59,7 +59,7 @@ fun LauncherSettings?.toUiSettingsOrDefault(): UiSettings =
 fun UiDensityOption.toUiDensity(): UiDensity = when (this) {
     UiDensityOption.COMPACT -> UiDensity.Compact
     UiDensityOption.SPACIOUS -> UiDensity.Spacious
-    UiDensityOption.COMFORTABLE -> UiDensity.Comfortable // Default fallback
+    UiDensityOption.COMFORTABLE -> UiDensity.Comfortable
 }
 
 /**


### PR DESCRIPTION
## Summary
- default the launcher settings and derived UI state to the compact density option
- update storage fallback to prefer the compact density option when data is missing or invalid

## Testing
- ./gradlew test *(fails: toolchain JDK 17 not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da4eaa814483218afa91da1a9f52e5