### PR TITLE
Fix long-press actions for search results

### DIFF
--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -245,7 +245,7 @@ fun HomeScreen(
                         viewModel.launchApp(packageName)
                     },
                     onAppLongClick = { searchItem ->
-                        // Remove pin/unpin functionality
+                        viewModel.showAppActionDialog(searchItem.appInfo)
                     },
                     onContactCall = { searchItem ->
                         viewModel.callContact(searchItem.contactInfo)


### PR DESCRIPTION
## Summary
- invoke the existing app action dialog when long-pressing an app result in home search

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da57e028ac8321abf3d0d81a17012a