### PR TITLE
Improve alphabet index scrolling and sorting

### DIFF
--- a/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerScreen.kt
@@ -615,14 +615,13 @@ private fun AlphabetIndex(
             }
         } ?: return null
 
-        val (entry, bounds) = candidate
-        val center = (bounds.start + bounds.endInclusive) / 2f
-        val fraction = if (totalHeight > 0f) {
-            (center / totalHeight).coerceIn(0f, 1f)
+        val (entry, _) = candidate
+        val pointerFraction = if (totalHeight > 0f) {
+            (clampedY / totalHeight).coerceIn(0f, 1f)
         } else {
             0f
         }
-        return entry to fraction
+        return entry to pointerFraction
     }
 
     Box(

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -798,14 +798,13 @@ private fun AlphabetIndex(
             }
         } ?: return null
 
-        val (entry, bounds) = candidate
-        val center = (bounds.start + bounds.endInclusive) / 2f
-        val fraction = if (totalHeight > 0f) {
-            (center / totalHeight).coerceIn(0f, 1f)
+        val (entry, _) = candidate
+        val pointerFraction = if (totalHeight > 0f) {
+            (clampedY / totalHeight).coerceIn(0f, 1f)
         } else {
             0f
         }
-        return entry to fraction
+        return entry to pointerFraction
     }
 
     Box(


### PR DESCRIPTION
## Summary
- ensure the app drawer falls back to a locale-aware, case-insensitive collator when sorting apps
- translate alphabet index scrubbing into proportional list positions so every app can be reached while dragging
- update the shared alphabet index component to track the user’s finger position for smoother previews

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK is not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da579245088321a604fc0ff49b03af