### PR TITLE
Improve usage permission navigation

### DIFF
--- a/app/src/main/java/com/talauncher/ui/insights/InsightsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/insights/InsightsScreen.kt
@@ -1,7 +1,5 @@
 package com.talauncher.ui.insights
 
-import android.content.Intent
-import android.provider.Settings
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -11,13 +9,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.talauncher.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -27,7 +23,6 @@ fun InsightsScreen(
     viewModel: InsightsViewModel
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val context = LocalContext.current
 
     Column(
         modifier = Modifier
@@ -57,12 +52,7 @@ fun InsightsScreen(
 
         if (!uiState.hasPermission) {
             PermissionCard(
-                onGrantPermission = {
-                    val intent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).apply {
-                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    }
-                    context.startActivity(intent)
-                }
+                onGrantPermission = viewModel::openUsageAccessSettings
             )
         } else if (uiState.isLoading) {
             Box(

--- a/app/src/main/java/com/talauncher/ui/insights/InsightsViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/insights/InsightsViewModel.kt
@@ -25,6 +25,10 @@ class InsightsViewModel(
         loadUsageStats()
     }
 
+    fun openUsageAccessSettings() {
+        permissionsHelper.openUsageAccessSettingsScreen()
+    }
+
     fun loadUsageStats() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true)

--- a/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
+++ b/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
@@ -183,11 +183,47 @@ open class PermissionsHelper(
         }
     }
 
+    fun openUsageAccessSettingsScreen() {
+        openUsageAccessSettings()
+    }
+
     private fun openUsageAccessSettings() {
-        val intent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).apply {
+        val packageName = context.packageName
+        val usageAccessIntent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).apply {
+            data = Uri.parse("package:$packageName")
+            putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        context.startActivity(intent)
+
+        if (startIntentSafely(usageAccessIntent)) {
+            return
+        }
+
+        val appDetailsIntent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.parse("package:$packageName")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        if (startIntentSafely(appDetailsIntent)) {
+            return
+        }
+
+        val fallbackIntent = Intent(Settings.ACTION_SETTINGS).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        startIntentSafely(fallbackIntent)
+    }
+
+    private fun startIntentSafely(intent: Intent): Boolean {
+        return runCatching {
+            if (intent.resolveActivity(context.packageManager) != null) {
+                context.startActivity(intent)
+                true
+            } else {
+                false
+            }
+        }.getOrDefault(false)
     }
 
     private fun openDefaultLauncherSettings() {


### PR DESCRIPTION
## Summary
- deep link the usage access settings intent directly to TALauncher and provide fallbacks
- expose a helper entry point for the usage access settings so UI components can reuse it
- update the insights screen to invoke the centralized helper when requesting permission

## Testing
- ./gradlew lint *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da5e057c248321bc39dfd8c82273a2