### PR TITLE
Reduce search debounce to 200ms

### DIFF
--- a/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
@@ -471,7 +471,7 @@ class AppDrawerViewModel(
     private fun setupDebouncedContactSearch() {
         viewModelScope.launch {
             searchQueryFlow
-                .debounce(300) // 300ms debounce
+                .debounce(200) // 200ms debounce
                 .collect { query ->
                     if (query.isNotBlank()) {
                         searchContacts(query)

--- a/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
@@ -469,7 +469,7 @@ class HomeViewModel(
     private fun setupDebouncedContactSearch() {
         viewModelScope.launch {
             searchQueryFlow
-                .debounce(300) // 300ms debounce
+                .debounce(200) // 200ms debounce
                 .collect { query ->
                     if (query.isNotBlank() && contactHelper != null &&
                         resolvedPermissionsHelper?.permissionState?.value?.hasContacts == true) {


### PR DESCRIPTION
## Summary
- reduce the debounced delay used for contact searches in the app drawer from 300ms to 200ms
- lower the home screen contact search debounce by the same amount to keep behavior consistent

## Testing
- ./gradlew test *(fails: missing Java 17 toolchain in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da9e4173808321ac04135edc07fb4e