### PR TITLE
Add search interaction tracking for recency-based sorting

### DIFF
--- a/app/src/main/java/com/talauncher/MainActivity.kt
+++ b/app/src/main/java/com/talauncher/MainActivity.kt
@@ -29,6 +29,7 @@ import com.talauncher.R
 import kotlinx.coroutines.launch
 import com.talauncher.data.database.LauncherDatabase
 import com.talauncher.data.repository.AppRepository
+import com.talauncher.data.repository.SearchInteractionRepository
 import com.talauncher.data.repository.SessionRepository
 import com.talauncher.data.repository.SettingsRepository
 // AppDrawer imports removed - functionality moved to HomeScreen
@@ -56,6 +57,7 @@ class MainActivity : ComponentActivity() {
     private var shouldNavigateToHome by mutableStateOf(false)
     private lateinit var sessionRepository: SessionRepository
     private lateinit var appRepository: AppRepository
+    private lateinit var searchInteractionRepository: SearchInteractionRepository
     private lateinit var errorHandler: MainErrorHandler
     private lateinit var permissionsHelper: PermissionsHelper
     private lateinit var usageStatsHelper: UsageStatsHelper
@@ -81,6 +83,7 @@ class MainActivity : ComponentActivity() {
                 this.sessionRepository,
                 this.errorHandler
             )
+            this.searchInteractionRepository = SearchInteractionRepository(database.searchInteractionDao())
 
             // Initialize session repository and observe expirations in a single coroutine
             // Add delay to allow UI to fully initialize first for Espresso tests
@@ -180,6 +183,7 @@ class MainActivity : ComponentActivity() {
                         } else {
                             TALauncherApp(
                                 appRepository = appRepository,
+                                searchInteractionRepository = searchInteractionRepository,
                                 settingsRepository = settingsRepository,
                                 permissionsHelper = permissionsHelper,
                                 usageStatsHelper = usageStatsHelper,
@@ -258,6 +262,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun TALauncherApp(
     appRepository: AppRepository,
+    searchInteractionRepository: SearchInteractionRepository,
     settingsRepository: SettingsRepository,
     permissionsHelper: PermissionsHelper,
     usageStatsHelper: UsageStatsHelper,
@@ -270,6 +275,7 @@ fun TALauncherApp(
 ) {
     LauncherNavigationPager(
         appRepository = appRepository,
+        searchInteractionRepository = searchInteractionRepository,
         settingsRepository = settingsRepository,
         permissionsHelper = permissionsHelper,
         usageStatsHelper = usageStatsHelper,
@@ -285,6 +291,7 @@ fun TALauncherApp(
 @Composable
 fun LauncherNavigationPager(
     appRepository: AppRepository,
+    searchInteractionRepository: SearchInteractionRepository,
     settingsRepository: SettingsRepository,
     permissionsHelper: PermissionsHelper,
     usageStatsHelper: UsageStatsHelper,
@@ -374,9 +381,10 @@ fun LauncherNavigationPager(
                     val context = LocalContext.current
                     val applicationContext = context.applicationContext
                     val homeViewModel: HomeViewModel = viewModel {
-                        HomeViewModel(
-                            appRepository = appRepository,
-                            settingsRepository = settingsRepository,
+        HomeViewModel(
+            appRepository = appRepository,
+            searchInteractionRepository = searchInteractionRepository,
+            settingsRepository = settingsRepository,
                             onLaunchApp = onLaunchApp,
                             sessionRepository = sessionRepository,
                             appContext = applicationContext,

--- a/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
+++ b/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
@@ -9,16 +9,18 @@ import android.content.Context
 import com.talauncher.data.model.AppInfo
 import com.talauncher.data.model.AppSession
 import com.talauncher.data.model.LauncherSettings
+import com.talauncher.data.model.SearchInteractionEntity
 
 @Database(
-    entities = [AppInfo::class, LauncherSettings::class, AppSession::class],
-    version = 15,
+    entities = [AppInfo::class, LauncherSettings::class, AppSession::class, SearchInteractionEntity::class],
+    version = 16,
     exportSchema = false
 )
 abstract class LauncherDatabase : RoomDatabase() {
     abstract fun appDao(): AppDao
     abstract fun settingsDao(): SettingsDao
     abstract fun appSessionDao(): AppSessionDao
+    abstract fun searchInteractionDao(): SearchInteractionDao
 
     companion object {
         @Volatile
@@ -232,6 +234,17 @@ abstract class LauncherDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_15_16 = object : Migration(15, 16) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS search_interactions (" +
+                        "itemKey TEXT NOT NULL PRIMARY KEY," +
+                        "lastUsedAt INTEGER NOT NULL" +
+                        ")"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): LauncherDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -252,7 +265,8 @@ abstract class LauncherDatabase : RoomDatabase() {
                     MIGRATION_11_12,
                     MIGRATION_12_13,
                     MIGRATION_13_14,
-                    MIGRATION_14_15
+                    MIGRATION_14_15,
+                    MIGRATION_15_16
                 ).build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/talauncher/data/database/SearchInteractionDao.kt
+++ b/app/src/main/java/com/talauncher/data/database/SearchInteractionDao.kt
@@ -1,0 +1,16 @@
+package com.talauncher.data.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.talauncher.data.model.SearchInteractionEntity
+
+@Dao
+interface SearchInteractionDao {
+    @Query("SELECT * FROM search_interactions WHERE itemKey IN (:keys)")
+    suspend fun getInteractions(keys: List<String>): List<SearchInteractionEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertInteraction(interaction: SearchInteractionEntity)
+}

--- a/app/src/main/java/com/talauncher/data/model/SearchInteraction.kt
+++ b/app/src/main/java/com/talauncher/data/model/SearchInteraction.kt
@@ -1,0 +1,10 @@
+package com.talauncher.data.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "search_interactions")
+data class SearchInteractionEntity(
+    @PrimaryKey val itemKey: String,
+    val lastUsedAt: Long
+)

--- a/app/src/main/java/com/talauncher/data/repository/SearchInteractionRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/SearchInteractionRepository.kt
@@ -1,0 +1,118 @@
+package com.talauncher.data.repository
+
+import com.talauncher.data.database.SearchInteractionDao
+import com.talauncher.data.model.SearchInteractionEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.collections.buildList
+
+class SearchInteractionRepository(
+    private val interactionDao: SearchInteractionDao,
+    private val timeProvider: () -> Long = System::currentTimeMillis
+) {
+    enum class ContactAction(val storageKey: String) {
+        CALL("call"),
+        MESSAGE("message"),
+        WHATSAPP("whatsapp"),
+        OPEN("open")
+    }
+
+    data class SearchInteractionSnapshot(
+        val appLastUsed: Map<String, Long>,
+        val contactLastUsed: Map<String, Long>
+    ) {
+        companion object {
+            val EMPTY = SearchInteractionSnapshot(emptyMap(), emptyMap())
+        }
+    }
+
+    suspend fun recordAppLaunch(packageName: String) {
+        val interaction = SearchInteractionEntity(
+            itemKey = buildAppKey(packageName),
+            lastUsedAt = timeProvider()
+        )
+        withContext(Dispatchers.IO) {
+            interactionDao.upsertInteraction(interaction)
+        }
+    }
+
+    suspend fun recordContactAction(contactId: String, action: ContactAction) {
+        val interaction = SearchInteractionEntity(
+            itemKey = buildContactKey(contactId, action),
+            lastUsedAt = timeProvider()
+        )
+        withContext(Dispatchers.IO) {
+            interactionDao.upsertInteraction(interaction)
+        }
+    }
+
+    suspend fun getLastUsedSnapshot(
+        appPackages: Collection<String>,
+        contactIds: Collection<String>
+    ): SearchInteractionSnapshot {
+        if (appPackages.isEmpty() && contactIds.isEmpty()) {
+            return SearchInteractionSnapshot.EMPTY
+        }
+
+        val keys = buildList {
+            appPackages.forEach { packageName ->
+                add(buildAppKey(packageName))
+            }
+            contactIds.forEach { contactId ->
+                ContactAction.values().forEach { action ->
+                    add(buildContactKey(contactId, action))
+                }
+            }
+        }
+
+        if (keys.isEmpty()) {
+            return SearchInteractionSnapshot.EMPTY
+        }
+
+        val interactions = withContext(Dispatchers.IO) {
+            interactionDao.getInteractions(keys)
+        }
+
+        if (interactions.isEmpty()) {
+            return SearchInteractionSnapshot.EMPTY
+        }
+
+        val appLastUsed = mutableMapOf<String, Long>()
+        val contactLastUsed = mutableMapOf<String, Long>()
+
+        interactions.forEach { entity ->
+            val segments = entity.itemKey.split(DELIMITER)
+            if (segments.isEmpty()) return@forEach
+            when (segments.first()) {
+                APP_PREFIX -> {
+                    val packageName = segments.getOrNull(1) ?: return@forEach
+                    val existing = appLastUsed[packageName]
+                    if (existing == null || entity.lastUsedAt > existing) {
+                        appLastUsed[packageName] = entity.lastUsedAt
+                    }
+                }
+                CONTACT_PREFIX -> {
+                    val contactId = segments.getOrNull(2) ?: return@forEach
+                    val existing = contactLastUsed[contactId]
+                    if (existing == null || entity.lastUsedAt > existing) {
+                        contactLastUsed[contactId] = entity.lastUsedAt
+                    }
+                }
+            }
+        }
+
+        return SearchInteractionSnapshot(appLastUsed, contactLastUsed)
+    }
+
+    private fun buildAppKey(packageName: String): String =
+        listOf(APP_PREFIX, packageName).joinToString(DELIMITER)
+
+    private fun buildContactKey(contactId: String, action: ContactAction): String =
+        listOf(CONTACT_PREFIX, action.storageKey, contactId).joinToString(DELIMITER)
+
+    companion object {
+        private const val APP_PREFIX = "app"
+        private const val CONTACT_PREFIX = "contact"
+        private const val DELIMITER = "|"
+    }
+}

--- a/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
@@ -13,6 +13,8 @@ import com.talauncher.data.model.AppInfo
 import com.talauncher.data.model.InstalledApp
 import com.talauncher.data.model.MathDifficulty
 import com.talauncher.data.repository.AppRepository
+import com.talauncher.data.repository.SearchInteractionRepository
+import com.talauncher.data.repository.SearchInteractionRepository.ContactAction
 import com.talauncher.data.repository.SettingsRepository
 import com.talauncher.utils.PermissionsHelper
 import com.talauncher.utils.UsageStatsHelper
@@ -34,7 +36,6 @@ import com.talauncher.ui.theme.UiSettings
 import com.talauncher.ui.theme.toUiSettingsOrDefault
 import java.text.Collator
 import java.util.Locale
-import kotlin.math.exp
 import kotlin.math.max
 import kotlin.math.min
 
@@ -111,6 +112,7 @@ data class AppDrawerUiState(
 class AppDrawerViewModel(
     private val appRepository: AppRepository,
     private val settingsRepository: SettingsRepository,
+    private val searchInteractionRepository: SearchInteractionRepository? = null,
     private val usageStatsHelper: UsageStatsHelper,
     private val permissionsHelper: PermissionsHelper,
     private val contactHelper: ContactHelper,
@@ -261,6 +263,7 @@ class AppDrawerViewModel(
             // Try to launch the app through repository (handles friction checks)
             val launched = appRepository.launchApp(packageName)
             if (launched) {
+                searchInteractionRepository?.recordAppLaunch(packageName)
                 // App was launched successfully, use callback if available
                 onLaunchApp?.invoke(packageName, null)
             }
@@ -286,6 +289,7 @@ class AppDrawerViewModel(
             // Log the reason for analytics/insights if needed
             val launched = appRepository.launchApp(packageName, bypassFriction = true)
             if (launched) {
+                searchInteractionRepository?.recordAppLaunch(packageName)
                 onLaunchApp?.invoke(packageName, null)
                 dismissFrictionDialog()
             }
@@ -334,6 +338,7 @@ class AppDrawerViewModel(
                 plannedDuration = durationMinutes
             )
             if (launched) {
+                searchInteractionRepository?.recordAppLaunch(packageName)
                 onLaunchApp?.invoke(packageName, durationMinutes)
             }
             dismissTimeLimitDialog()
@@ -536,18 +541,30 @@ class AppDrawerViewModel(
 
     fun callContact(contact: ContactInfo) {
         contactHelper.callContact(contact)
+        viewModelScope.launch {
+            searchInteractionRepository?.recordContactAction(contact.id, ContactAction.CALL)
+        }
     }
 
     fun messageContact(contact: ContactInfo) {
         contactHelper.messageContact(contact)
+        viewModelScope.launch {
+            searchInteractionRepository?.recordContactAction(contact.id, ContactAction.MESSAGE)
+        }
     }
 
     fun whatsAppContact(contact: ContactInfo) {
         contactHelper.whatsAppContact(contact)
+        viewModelScope.launch {
+            searchInteractionRepository?.recordContactAction(contact.id, ContactAction.WHATSAPP)
+        }
     }
 
     fun openContact(contact: ContactInfo) {
         contactHelper.openContact(contact)
+        viewModelScope.launch {
+            searchInteractionRepository?.recordContactAction(contact.id, ContactAction.OPEN)
+        }
     }
 
     fun onAlphabetIndexFocused(entry: AlphabetIndexEntry, fraction: Float) {
@@ -581,28 +598,27 @@ class AppDrawerViewModel(
     }
 
     private suspend fun buildSectionsAndIndexAsync(apps: List<AppInfo>, recentApps: List<AppInfo>, searchQuery: String, locale: Locale, collator: Collator) {
+        val interactionSnapshot = searchInteractionRepository?.getLastUsedSnapshot(
+            appPackages = apps.map { it.packageName },
+            contactIds = emptyList()
+        ) ?: SearchInteractionRepository.SearchInteractionSnapshot.EMPTY
+        val appLastUsed = interactionSnapshot.appLastUsed
+
         val filteredApps = if (searchQuery.isBlank()) {
             apps.filter { !it.isHidden }
         } else {
-            // Use fuzzy search with recency scoring for better results
-            val hasUsageStatsPermission = permissionsHelper.permissionState.value.hasUsageStats
-            val usageStats = if (hasUsageStatsPermission) {
-                withContext(Dispatchers.IO) {
-                    usageStatsHelper.getPast48HoursUsageStats(true).associateBy { it.packageName }
-                }
-            } else {
-                emptyMap()
-            }
-
             apps.filter { !it.isHidden }
                 .mapNotNull { app ->
                     val baseScore = calculateRelevanceScore(searchQuery, app.appName)
                     if (baseScore > 0) {
-                        val recencyScore = calculateRecencyScore(app.packageName, usageStats)
-                        app to (baseScore + recencyScore)
+                        Triple(app, baseScore, appLastUsed[app.packageName])
                     } else null
                 }
-                .sortedByDescending { it.second }
+                .sortedWith(
+                    compareByDescending<Triple<AppInfo, Int, Long?>> { it.second }
+                        .thenByDescending { it.third ?: Long.MIN_VALUE }
+                        .thenBy { it.first.appName.lowercase(locale) }
+                )
                 .map { it.first }
         }
 
@@ -613,7 +629,7 @@ class AppDrawerViewModel(
         val filteredApps = if (searchQuery.isBlank()) {
             apps.filter { !it.isHidden }
         } else {
-            // For non-search queries or when called synchronously, skip usage stats to avoid blocking
+            // For non-search queries or when called synchronously, skip last-used lookups to avoid blocking
             apps.filter { !it.isHidden }
                 .mapNotNull { app ->
                     val baseScore = calculateRelevanceScore(searchQuery, app.appName)
@@ -761,22 +777,6 @@ class AppDrawerViewModel(
         return dp[s1.length][s2.length]
     }
 
-    private fun calculateRecencyScore(packageName: String, usageStats: Map<String, com.talauncher.data.model.AppUsage>): Int {
-        val usageApp = usageStats[packageName] ?: return 0
-
-        // Calculate recency boost based on usage time and frequency
-        val usageTimeHours = TimeUnit.MILLISECONDS.toHours(usageApp.timeInForeground)
-        val now = System.currentTimeMillis()
-        val lastUsedHours = TimeUnit.MILLISECONDS.toHours(now - usageApp.lastTimeUsed)
-
-        // Exponential decay for recency (higher boost for more recent usage)
-        val recencyFactor = exp(-lastUsedHours / 24.0) // Decay over 24 hours
-
-        // Usage time factor (more used apps get higher boost)
-        val usageFactor = min(usageTimeHours / 2.0, 5.0) // Cap at 5 points
-
-        return (recencyFactor * usageFactor * 20).toInt() // Max recency boost of ~20 points
-    }
 }
 
 private data class TimeLimitPromptState(


### PR DESCRIPTION
## Summary
- add a Room entity/DAO/repository for persisted search interactions along with a database migration
- inject the search interaction repository into the home and app drawer flows to record launches/actions and use recency in search ordering
- extend the UI test scaffolding with a fake search interaction DAO and pass the repository into the pager

## Testing
- `./gradlew testDebugUnitTest` *(fails: missing Java 17 toolchain in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daa085e3f4832183309dcf457fff27