### PR TITLE
Speed up instrumentation tests by bypassing onboarding gate

### DIFF
--- a/app/src/androidTest/java/com/talauncher/DialogsAndPermissionsTest.kt
+++ b/app/src/androidTest/java/com/talauncher/DialogsAndPermissionsTest.kt
@@ -10,6 +10,7 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.espresso.IdlingRegistry
 import com.talauncher.utils.EspressoIdlingResource
+import com.talauncher.utils.skipOnboardingIfNeeded
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -26,6 +27,7 @@ class DialogsAndPermissionsTest {
     @Before
     fun setUp() {
         IdlingRegistry.getInstance().register(EspressoIdlingResource.getIdlingResource())
+        composeTestRule.skipOnboardingIfNeeded()
     }
 
     @After
@@ -33,57 +35,9 @@ class DialogsAndPermissionsTest {
         IdlingRegistry.getInstance().unregister(EspressoIdlingResource.getIdlingResource())
     }
 
-    private fun ensureOnHomeScreen() {
-        // Wait for either onboarding screen or main app to appear
-        composeTestRule.waitUntil(timeoutMillis = 15_000) {
-            try {
-                // Check if we're already on the main app
-                composeTestRule.onNodeWithTag("launcher_navigation_pager").assertExists()
-                return@waitUntil true
-            } catch (e: AssertionError) {
-                // Check if we're on onboarding screen
-                try {
-                    composeTestRule.onNodeWithTag("onboarding_step_default_launcher_button").assertExists()
-                    // Complete onboarding flow
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_usage_stats_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Already completed */ }
-
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_notifications_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Not required or already completed */ }
-
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_overlay_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Already completed */ }
-
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_default_launcher_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Already completed */ }
-
-                    // Check if we reached main app after onboarding
-                    try {
-                        composeTestRule.onNodeWithTag("launcher_navigation_pager").assertExists()
-                        return@waitUntil true
-                    } catch (ex: AssertionError) {
-                        return@waitUntil false
-                    }
-                } catch (e2: AssertionError) {
-                    // Neither onboarding nor main app found yet
-                    return@waitUntil false
-                }
-            }
-        }
-    }
-
     @Test
     fun appActionDialog_HideApp() {
         Log.d("DialogsAndPermissionsTest", "Running appActionDialog_HideApp test")
-        ensureOnHomeScreen()
 
         // 1. Wait for app list to load and get first app
         composeTestRule.waitUntil(5000) {
@@ -118,7 +72,6 @@ class DialogsAndPermissionsTest {
     @Test
     fun frictionDialogForDistractingApps() {
         Log.d("DialogsAndPermissionsTest", "Running frictionDialogForDistractingApps test")
-        ensureOnHomeScreen()
 
         // 1. Wait for app list to load and get first app
         composeTestRule.waitUntil(5000) {
@@ -176,7 +129,6 @@ class DialogsAndPermissionsTest {
     @Test
     fun contactsPermissionFlow() {
         Log.d("DialogsAndPermissionsTest", "Running contactsPermissionFlow test")
-        ensureOnHomeScreen()
 
         // 1. Ensure contacts permission is revoked.
         val instrumentation = InstrumentationRegistry.getInstrumentation()

--- a/app/src/androidTest/java/com/talauncher/HomeScreenInteractionTest.kt
+++ b/app/src/androidTest/java/com/talauncher/HomeScreenInteractionTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.espresso.IdlingRegistry
 import com.talauncher.utils.EspressoIdlingResource
+import com.talauncher.utils.skipOnboardingIfNeeded
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -28,6 +29,7 @@ class HomeScreenInteractionTest {
     fun setUp() {
         Intents.init()
         IdlingRegistry.getInstance().register(EspressoIdlingResource.getIdlingResource())
+        composeTestRule.skipOnboardingIfNeeded()
     }
 
     @After
@@ -36,57 +38,9 @@ class HomeScreenInteractionTest {
         Intents.release()
     }
 
-    private fun ensureOnHomeScreen() {
-        // Wait for either onboarding screen or main app to appear
-        composeTestRule.waitUntil(timeoutMillis = 15_000) {
-            try {
-                // Check if we're already on the main app
-                composeTestRule.onNodeWithTag("launcher_navigation_pager").assertExists()
-                return@waitUntil true
-            } catch (e: AssertionError) {
-                // Check if we're on onboarding screen
-                try {
-                    composeTestRule.onNodeWithTag("onboarding_step_default_launcher_button").assertExists()
-                    // Complete onboarding flow
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_usage_stats_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Already completed */ }
-
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_notifications_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Not required or already completed */ }
-
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_overlay_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Already completed */ }
-
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_default_launcher_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Already completed */ }
-
-                    // Check if we reached main app after onboarding
-                    try {
-                        composeTestRule.onNodeWithTag("launcher_navigation_pager").assertExists()
-                        return@waitUntil true
-                    } catch (ex: AssertionError) {
-                        return@waitUntil false
-                    }
-                } catch (e2: AssertionError) {
-                    // Neither onboarding nor main app found yet
-                    return@waitUntil false
-                }
-            }
-        }
-    }
-
     @Test
     fun launchAppFromAllAppsList() {
         Log.d("HomeScreenInteractionTest", "Running launchAppFromAllAppsList test")
-        ensureOnHomeScreen()
 
         // Scenario: Launch an app from the "All Apps" list
         // 1. Wait for the app list to load and find the first available app
@@ -119,7 +73,6 @@ class HomeScreenInteractionTest {
     @Test
     fun launchRecentApp() {
         Log.d("HomeScreenInteractionTest", "Running launchRecentApp test")
-        ensureOnHomeScreen()
 
         // Scenario: Launch a "Recent App"
         // 1. Wait for app list and launch the first app to make it "recent"

--- a/app/src/androidTest/java/com/talauncher/OnboardingFlowTest.kt
+++ b/app/src/androidTest/java/com/talauncher/OnboardingFlowTest.kt
@@ -1,0 +1,68 @@
+package com.talauncher
+
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.talauncher.utils.EspressoIdlingResource
+import com.talauncher.utils.markOnboardingComplete
+import com.talauncher.utils.resetOnboardingState
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OnboardingFlowTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun setUp() {
+        IdlingRegistry.getInstance().register(EspressoIdlingResource.getIdlingResource())
+        resetOnboardingState()
+        composeTestRule.activityRule.scenario.recreate()
+        composeTestRule.waitForIdle()
+    }
+
+    @After
+    fun tearDown() {
+        markOnboardingComplete()
+        IdlingRegistry.getInstance().unregister(EspressoIdlingResource.getIdlingResource())
+    }
+
+    @Test
+    fun completeOnboardingFlowDisplaysHomeScreen() {
+        waitForOnboardingToAppear()
+
+        clickStepIfPresent("onboarding_step_usage_stats_button")
+        clickStepIfPresent("onboarding_step_notifications_button")
+        clickStepIfPresent("onboarding_step_overlay_button")
+        clickStepIfPresent("onboarding_step_default_launcher_button")
+
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            composeTestRule.onAllNodesWithTag("launcher_navigation_pager").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("launcher_navigation_pager").assertExists()
+    }
+
+    private fun waitForOnboardingToAppear() {
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            composeTestRule.onAllNodesWithTag("onboarding_step_default_launcher_button").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun clickStepIfPresent(tag: String) {
+        val nodes = composeTestRule.onAllNodesWithTag(tag).fetchSemanticsNodes()
+        if (nodes.isNotEmpty()) {
+            composeTestRule.onNodeWithTag(tag).performClick()
+            composeTestRule.waitForIdle()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/talauncher/SettingsFlowTest.kt
+++ b/app/src/androidTest/java/com/talauncher/SettingsFlowTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.espresso.IdlingRegistry
 import com.talauncher.utils.EspressoIdlingResource
+import com.talauncher.utils.skipOnboardingIfNeeded
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -25,6 +26,7 @@ class SettingsFlowTest {
     @Before
     fun setUp() {
         IdlingRegistry.getInstance().register(EspressoIdlingResource.getIdlingResource())
+        composeTestRule.skipOnboardingIfNeeded()
     }
 
     @After
@@ -32,57 +34,9 @@ class SettingsFlowTest {
         IdlingRegistry.getInstance().unregister(EspressoIdlingResource.getIdlingResource())
     }
 
-    private fun ensureOnHomeScreen() {
-        // Wait for either onboarding screen or main app to appear
-        composeTestRule.waitUntil(timeoutMillis = 15_000) {
-            try {
-                // Check if we're already on the main app
-                composeTestRule.onNodeWithTag("launcher_navigation_pager").assertExists()
-                return@waitUntil true
-            } catch (e: AssertionError) {
-                // Check if we're on onboarding screen
-                try {
-                    composeTestRule.onNodeWithTag("onboarding_step_default_launcher_button").assertExists()
-                    // Complete onboarding flow
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_usage_stats_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Already completed */ }
-
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_notifications_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Not required or already completed */ }
-
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_overlay_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Already completed */ }
-
-                    try {
-                        composeTestRule.onNodeWithTag("onboarding_step_default_launcher_button").performClick()
-                        composeTestRule.waitForIdle()
-                    } catch (ex: Exception) { /* Already completed */ }
-
-                    // Check if we reached main app after onboarding
-                    try {
-                        composeTestRule.onNodeWithTag("launcher_navigation_pager").assertExists()
-                        return@waitUntil true
-                    } catch (ex: AssertionError) {
-                        return@waitUntil false
-                    }
-                } catch (e2: AssertionError) {
-                    // Neither onboarding nor main app found yet
-                    return@waitUntil false
-                }
-            }
-        }
-    }
-
     @Test
     fun changeColorPalette() {
         Log.d("SettingsFlowTest", "Running changeColorPalette test")
-        ensureOnHomeScreen()
 
         // 1. From the HomeScreen, swipe right to navigate to the SettingsScreen.
         composeTestRule.onNodeWithTag("launcher_navigation_pager").performTouchInput { swipeRight() }
@@ -100,7 +54,6 @@ class SettingsFlowTest {
     @Test
     fun changeThemeMode() {
         Log.d("SettingsFlowTest", "Running changeThemeMode test")
-        ensureOnHomeScreen()
 
         // 1. From the HomeScreen, swipe right to navigate to the SettingsScreen.
         composeTestRule.onNodeWithTag("launcher_navigation_pager").performTouchInput { swipeRight() }
@@ -123,7 +76,6 @@ class SettingsFlowTest {
     @Test
     fun toggleWallpaperAndChangeBlur() {
         Log.d("SettingsFlowTest", "Running toggleWallpaperAndChangeBlur test")
-        ensureOnHomeScreen()
 
         // 1. Navigate to the "UI & Theme" tab in Settings.
         composeTestRule.onNodeWithTag("launcher_navigation_pager").performTouchInput { swipeRight() }
@@ -153,7 +105,6 @@ class SettingsFlowTest {
     @Test
     fun addAndConfigureDistractingApp() {
         Log.d("SettingsFlowTest", "Running addAndConfigureDistractingApp test")
-        ensureOnHomeScreen()
 
         // 1. Navigate to the "Distracting Apps" tab in Settings
         composeTestRule.onNodeWithTag("launcher_navigation_pager").performTouchInput { swipeRight() }

--- a/app/src/androidTest/java/com/talauncher/ThemeSettingsTest.kt
+++ b/app/src/androidTest/java/com/talauncher/ThemeSettingsTest.kt
@@ -9,6 +9,7 @@ import androidx.test.espresso.IdlingRegistry
 import com.talauncher.data.model.ColorPaletteOption
 import com.talauncher.data.model.ThemeModeOption
 import com.talauncher.utils.EspressoIdlingResource
+import com.talauncher.utils.skipOnboardingIfNeeded
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -28,6 +29,7 @@ class ThemeSettingsTest {
     @Before
     fun setUp() {
         IdlingRegistry.getInstance().register(EspressoIdlingResource.getIdlingResource())
+        composeTestRule.skipOnboardingIfNeeded()
     }
 
     @After
@@ -35,60 +37,7 @@ class ThemeSettingsTest {
         IdlingRegistry.getInstance().unregister(EspressoIdlingResource.getIdlingResource())
     }
 
-    private fun ensureOnHomeScreen() {
-        // Wait for either onboarding screen or main app to appear
-        composeTestRule.waitUntil(timeoutMillis = 15_000) {
-            try {
-                // Check if we're already on the main app
-                composeTestRule.onNodeWithTag("launcher_navigation_pager").assertExists()
-                return@waitUntil true
-            } catch (e: AssertionError) {
-                // Check if we're on onboarding screen
-                try {
-                    composeTestRule.onNodeWithTag("onboarding_step_default_launcher_button").assertExists()
-                    // Complete onboarding flow
-                    completeOnboardingIfNeeded()
-
-                    // Check if we reached main app after onboarding
-                    try {
-                        composeTestRule.onNodeWithTag("launcher_navigation_pager").assertExists()
-                        return@waitUntil true
-                    } catch (ex: AssertionError) {
-                        return@waitUntil false
-                    }
-                } catch (e2: AssertionError) {
-                    // Neither onboarding nor main app found yet
-                    return@waitUntil false
-                }
-            }
-        }
-    }
-
-    private fun completeOnboardingIfNeeded() {
-        try {
-            composeTestRule.onNodeWithTag("onboarding_step_usage_stats_button").performClick()
-            composeTestRule.waitForIdle()
-        } catch (ex: Exception) { /* Already completed */ }
-
-        try {
-            composeTestRule.onNodeWithTag("onboarding_step_notifications_button").performClick()
-            composeTestRule.waitForIdle()
-        } catch (ex: Exception) { /* Not required or already completed */ }
-
-        try {
-            composeTestRule.onNodeWithTag("onboarding_step_overlay_button").performClick()
-            composeTestRule.waitForIdle()
-        } catch (ex: Exception) { /* Already completed */ }
-
-        try {
-            composeTestRule.onNodeWithTag("onboarding_step_default_launcher_button").performClick()
-            composeTestRule.waitForIdle()
-        } catch (ex: Exception) { /* Already completed */ }
-    }
-
     private fun navigateToThemeSettings() {
-        ensureOnHomeScreen()
-
         // Navigate to Settings screen
         composeTestRule.onNodeWithTag("launcher_navigation_pager").performTouchInput { swipeRight() }
         composeTestRule.waitForIdle()

--- a/app/src/androidTest/java/com/talauncher/utils/OnboardingTestHelper.kt
+++ b/app/src/androidTest/java/com/talauncher/utils/OnboardingTestHelper.kt
@@ -1,0 +1,53 @@
+package com.talauncher.utils
+
+import android.content.Context
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.talauncher.MainActivity
+import com.talauncher.data.database.LauncherDatabase
+import com.talauncher.data.repository.SettingsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+private fun getSettingsRepository(): SettingsRepository {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val database = LauncherDatabase.getDatabase(context)
+    return SettingsRepository(database.settingsDao())
+}
+
+fun markOnboardingComplete() {
+    runBlocking {
+        withContext(Dispatchers.IO) {
+            getSettingsRepository().completeOnboarding()
+        }
+    }
+}
+
+fun resetOnboardingState() {
+    runBlocking {
+        withContext(Dispatchers.IO) {
+            val repository = getSettingsRepository()
+            val settings = repository.getSettingsSync()
+            repository.updateSettings(settings.copy(isOnboardingCompleted = false))
+        }
+    }
+}
+
+fun AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>.skipOnboardingIfNeeded() {
+    markOnboardingComplete()
+
+    waitUntil(timeoutMillis = 10_000) {
+        try {
+            onNodeWithTag("launcher_navigation_pager").assertExists()
+            true
+        } catch (error: AssertionError) {
+            false
+        }
+    }
+
+    waitForIdle()
+}


### PR DESCRIPTION
## Summary
- add a shared helper to flip onboarding state directly in instrumentation tests
- update existing UI suites to rely on the helper instead of driving the onboarding flow
- add a focused onboarding test that covers the full gate so the flow still has coverage

## Testing
- not run (instrumentation tests require a device)

------
https://chatgpt.com/codex/tasks/task_e_68db77d6388083218f3119ccfb321295