### PR TITLE
Add configurable app icon styles and render icons in lists

### DIFF
--- a/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
+++ b/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
@@ -13,7 +13,7 @@ import com.talauncher.data.model.SearchInteractionEntity
 
 @Database(
     entities = [AppInfo::class, LauncherSettings::class, AppSession::class, SearchInteractionEntity::class],
-    version = 16,
+    version = 17,
     exportSchema = false
 )
 abstract class LauncherDatabase : RoomDatabase() {
@@ -245,6 +245,14 @@ abstract class LauncherDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_16_17 = object : Migration(16, 17) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE launcher_settings ADD COLUMN appIconStyle TEXT NOT NULL DEFAULT 'THEMED'"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): LauncherDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -266,7 +274,8 @@ abstract class LauncherDatabase : RoomDatabase() {
                     MIGRATION_12_13,
                     MIGRATION_13_14,
                     MIGRATION_14_15,
-                    MIGRATION_15_16
+                    MIGRATION_15_16,
+                    MIGRATION_16_17
                 ).build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
+++ b/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
@@ -34,6 +34,7 @@ data class LauncherSettings(
 
     // New 2025 minimalist UI customization options
     val colorPalette: ColorPaletteOption = ColorPaletteOption.DEFAULT,
+    val appIconStyle: AppIconStyleOption = AppIconStyleOption.THEMED,
     val customColorOption: String? = null, // Selected custom color from ColorPalettes.CustomColorOptions
     val customPrimaryColor: String? = null, // Custom primary color (hex)
     val customSecondaryColor: String? = null, // Custom secondary color (hex)

--- a/app/src/main/java/com/talauncher/data/model/SettingsOptions.kt
+++ b/app/src/main/java/com/talauncher/data/model/SettingsOptions.kt
@@ -72,6 +72,22 @@ enum class ColorPaletteOption(val label: String) {
     }
 }
 
+enum class AppIconStyleOption(val label: String) {
+    THEMED("Theme color"),
+    ORIGINAL("Original colors"),
+    HIDDEN("No icons");
+
+    val storageValue: String
+        get() = name
+
+    companion object {
+        fun fromStorageValue(value: String?): AppIconStyleOption {
+            val normalized = value?.lowercase(Locale.US)
+            return entries.firstOrNull { it.name.lowercase(Locale.US) == normalized } ?: THEMED
+        }
+    }
+}
+
 enum class ThemeModeOption(val label: String) {
     SYSTEM("System"),
     LIGHT("Light"),

--- a/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
@@ -2,6 +2,7 @@ package com.talauncher.data.repository
 
 import com.talauncher.data.database.SettingsDao
 import com.talauncher.data.model.ColorPaletteOption
+import com.talauncher.data.model.AppIconStyleOption
 import com.talauncher.data.model.LauncherSettings
 import com.talauncher.data.model.MathDifficulty
 import com.talauncher.data.model.ThemeModeOption
@@ -129,6 +130,11 @@ class SettingsRepository(private val settingsDao: SettingsDao) {
     suspend fun updateColorPalette(palette: ColorPaletteOption) {
         val settings = getSettingsSync()
         updateSettings(settings.copy(colorPalette = palette))
+    }
+
+    suspend fun updateAppIconStyle(style: AppIconStyleOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(appIconStyle = style))
     }
 
     suspend fun setCustomPalette(

--- a/app/src/main/java/com/talauncher/ui/components/SearchComponents.kt
+++ b/app/src/main/java/com/talauncher/ui/components/SearchComponents.kt
@@ -71,6 +71,7 @@ fun UnifiedSearchResults(
                     is SearchItem.App -> {
                         ModernAppItem(
                             appName = searchItem.appInfo.appName,
+                            packageName = searchItem.appInfo.packageName,
                             isHidden = searchItem.appInfo.isHidden,
                             onClick = {
                                 keyboardController?.hide()
@@ -81,7 +82,8 @@ fun UnifiedSearchResults(
                                 onAppLongClick(searchItem)
                             },
                             enableGlassmorphism = uiSettings.enableGlassmorphism,
-                            uiDensity = uiSettings.getUiDensity()
+                            uiDensity = uiSettings.getUiDensity(),
+                            appIconStyle = uiSettings.appIconStyle
                         )
                     }
                     is SearchItem.Contact -> {
@@ -220,6 +222,7 @@ fun AppDrawerUnifiedSearchResults(
             items(filteredApps, key = { it.packageName }) { app ->
                 ModernAppItem(
                     appName = app.appName,
+                    packageName = app.packageName,
                     isHidden = app.isHidden,
                     onClick = {
                         keyboardController?.hide()
@@ -230,7 +233,8 @@ fun AppDrawerUnifiedSearchResults(
                         onAppLongClick(app)
                     },
                     enableGlassmorphism = uiSettings.enableGlassmorphism,
-                    uiDensity = uiSettings.getUiDensity()
+                    uiDensity = uiSettings.getUiDensity(),
+                    appIconStyle = uiSettings.appIconStyle
                 )
             }
         }

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.isActive
 import com.talauncher.R
 import com.talauncher.data.model.AppInfo
 import com.talauncher.data.model.UiDensityOption
+import com.talauncher.data.model.AppIconStyleOption
 import com.talauncher.data.model.WeatherDisplayOption
 import com.talauncher.ui.components.ContactItem
 import com.talauncher.ui.components.GoogleSearchItem
@@ -59,6 +60,7 @@ import com.talauncher.ui.components.TimeLimitDialog
 import com.talauncher.ui.components.ModernGlassCard
 import com.talauncher.ui.components.ModernSearchField
 import com.talauncher.ui.components.ModernAppItem
+import com.talauncher.ui.components.AppIcon
 import com.talauncher.ui.components.ModernBackdrop
 import com.talauncher.ui.components.UiDensity
 import com.talauncher.ui.components.UnifiedSearchResults
@@ -283,6 +285,7 @@ fun HomeScreen(
                     },
                     uiSettings = UiSettings(
                         colorPalette = uiState.colorPalette,
+                        appIconStyle = uiState.appIconStyle,
                         enableGlassmorphism = uiState.enableGlassmorphism,
                         enableAnimations = uiState.enableAnimations,
                         uiDensity = uiState.uiDensity,
@@ -347,14 +350,15 @@ fun HomeScreen(
                             }
 
                             items(uiState.recentApps, key = { "recent_${it.packageName}" }) { app ->
-                                RecentAppItem(
-                                    appInfo = app,
-                                    onClick = { viewModel.launchApp(app.packageName) },
-                                    onLongClick = {
-                                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                        viewModel.showAppActionDialog(app)
-                                    }
-                                )
+                            RecentAppItem(
+                                appInfo = app,
+                                onClick = { viewModel.launchApp(app.packageName) },
+                                onLongClick = {
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    viewModel.showAppActionDialog(app)
+                                },
+                                iconStyle = uiState.appIconStyle
+                            )
                             }
 
                             item {
@@ -375,11 +379,13 @@ fun HomeScreen(
                         items(uiState.allVisibleApps, key = { it.packageName }) { app ->
                             ModernAppItem(
                                 appName = app.appName,
+                                packageName = app.packageName,
                                 onClick = { viewModel.launchApp(app.packageName) },
                                 onLongClick = {
                                     hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                     viewModel.showAppActionDialog(app)
                                 },
+                                appIconStyle = uiState.appIconStyle,
                                 enableGlassmorphism = uiState.enableGlassmorphism,
                                 uiDensity = uiState.uiDensity.toUiDensity()
                             )
@@ -885,7 +891,8 @@ private fun AlphabetIndex(
 fun RecentAppItem(
     appInfo: AppInfo,
     onClick: () -> Unit,
-    onLongClick: () -> Unit
+    onLongClick: () -> Unit,
+    iconStyle: AppIconStyleOption
 ) {
     PrimerCard(
         modifier = Modifier
@@ -906,6 +913,14 @@ fun RecentAppItem(
                 .heightIn(min = PrimerListItemDefaults.minHeight),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            if (iconStyle != AppIconStyleOption.HIDDEN) {
+                AppIcon(
+                    packageName = appInfo.packageName,
+                    appName = appInfo.appName,
+                    iconStyle = iconStyle
+                )
+                Spacer(modifier = Modifier.width(PrimerSpacing.md))
+            }
             Text(
                 text = appInfo.appName,
                 modifier = Modifier.weight(1f),

--- a/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import com.talauncher.R
 import com.talauncher.data.model.AppInfo
 import com.talauncher.data.model.AppSession
 import com.talauncher.data.model.ColorPaletteOption
+import com.talauncher.data.model.AppIconStyleOption
 import com.talauncher.data.model.MathDifficulty
 import com.talauncher.data.model.UiDensityOption
 import com.talauncher.data.model.WeatherDisplayOption
@@ -249,6 +250,7 @@ class HomeViewModel(
                             weatherTemperatureUnit = settings?.weatherTemperatureUnit
                                 ?: WeatherTemperatureUnit.CELSIUS,
                             colorPalette = settings?.colorPalette ?: ColorPaletteOption.DEFAULT,
+                            appIconStyle = settings?.appIconStyle ?: AppIconStyleOption.THEMED,
                             wallpaperBlurAmount = settings?.wallpaperBlurAmount ?: 0f,
                             customWallpaperPath = settings?.customWallpaperPath,
                             enableGlassmorphism = settings?.enableGlassmorphism ?: true,
@@ -1575,6 +1577,7 @@ data class HomeUiState(
     val weatherDailyHigh: Double? = null,
     val weatherDailyLow: Double? = null,
     val colorPalette: ColorPaletteOption = ColorPaletteOption.DEFAULT,
+    val appIconStyle: AppIconStyleOption = AppIconStyleOption.THEMED,
     val wallpaperBlurAmount: Float = 0f,
     val enableGlassmorphism: Boolean = true,
     val uiDensity: UiDensityOption = UiDensityOption.COMPACT,

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
@@ -350,22 +350,23 @@ fun UIThemeSettings(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
 
-                    ChipGrid(
-                        items = AppIconStyleOption.entries,
+                    Column(
                         modifier = Modifier.fillMaxWidth(),
-                        itemsPerRow = 3
-                    ) { option ->
-                        FilterChip(
-                            selected = appIconStyle == option,
-                            onClick = { onUpdateAppIconStyle(option) },
-                            label = {
-                                Text(
-                                    text = option.label,
-                                    maxLines = 1,
-                                    softWrap = false
-                                )
-                            }
-                        )
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        AppIconStyleOption.entries.forEach { option ->
+                            FilterChip(
+                                selected = appIconStyle == option,
+                                onClick = { onUpdateAppIconStyle(option) },
+                                label = {
+                                    Text(
+                                        text = option.label,
+                                        maxLines = 1
+                                    )
+                                },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.talauncher.R
 import com.talauncher.data.model.ColorPaletteOption
+import com.talauncher.data.model.AppIconStyleOption
 import com.talauncher.data.model.MathDifficulty
 import com.talauncher.data.model.ThemeModeOption
 import com.talauncher.data.model.UiDensityOption
@@ -152,6 +153,8 @@ fun SettingsScreen(
                 onToggleShowWallpaper = viewModel::updateShowWallpaper,
                 colorPalette = uiState.colorPalette,
                 onUpdateColorPalette = viewModel::updateColorPalette,
+                appIconStyle = uiState.appIconStyle,
+                onUpdateAppIconStyle = viewModel::updateAppIconStyle,
                 customColorOption = uiState.customColorOption,
                 onUpdateCustomColorOption = viewModel::updateCustomColorOption,
                 customPrimaryColor = uiState.customPrimaryColor,
@@ -280,6 +283,8 @@ fun UIThemeSettings(
     onToggleShowWallpaper: (Boolean) -> Unit,
     colorPalette: ColorPaletteOption,
     onUpdateColorPalette: (ColorPaletteOption) -> Unit,
+    appIconStyle: AppIconStyleOption,
+    onUpdateAppIconStyle: (AppIconStyleOption) -> Unit,
     customColorOption: String?,
     onUpdateCustomColorOption: (String) -> Unit,
     customPrimaryColor: String?,
@@ -320,6 +325,50 @@ fun UIThemeSettings(
                 onCustomPrimaryColorSelected = onUpdateCustomPrimaryColor,
                 onCustomSecondaryColorSelected = onUpdateCustomSecondaryColor
             )
+        }
+
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Text(
+                        text = "App Icons",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = "Choose how icons appear beside app names",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    ChipGrid(
+                        items = AppIconStyleOption.entries,
+                        modifier = Modifier.fillMaxWidth(),
+                        itemsPerRow = 3
+                    ) { option ->
+                        FilterChip(
+                            selected = appIconStyle == option,
+                            onClick = { onUpdateAppIconStyle(option) },
+                            label = {
+                                Text(
+                                    text = option.label,
+                                    maxLines = 1,
+                                    softWrap = false
+                                )
+                            }
+                        )
+                    }
+                }
+            }
         }
 
         item {

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.talauncher.data.model.AppInfo
 import com.talauncher.data.model.ColorPaletteOption
+import com.talauncher.data.model.AppIconStyleOption
 import com.talauncher.data.model.InstalledApp
 import com.talauncher.data.model.MathDifficulty
 import com.talauncher.data.model.ThemeModeOption
@@ -73,6 +74,7 @@ class SettingsViewModel(
                     buildBranch = settings?.buildBranch,
                     buildTime = settings?.buildTime,
                     colorPalette = settings?.colorPalette ?: ColorPaletteOption.DEFAULT,
+                    appIconStyle = settings?.appIconStyle ?: AppIconStyleOption.THEMED,
                     customColorOption = settings?.customColorOption,
                     customPrimaryColor = settings?.customPrimaryColor,
                     customSecondaryColor = settings?.customSecondaryColor,
@@ -196,6 +198,12 @@ class SettingsViewModel(
             } else {
                 settingsRepository.updateColorPalette(palette)
             }
+        }
+    }
+
+    fun updateAppIconStyle(style: AppIconStyleOption) {
+        viewModelScope.launch {
+            settingsRepository.updateAppIconStyle(style)
         }
     }
 
@@ -349,6 +357,7 @@ data class SettingsUiState(
     val buildBranch: String? = null,
     val buildTime: String? = null,
     val colorPalette: ColorPaletteOption = ColorPaletteOption.DEFAULT,
+    val appIconStyle: AppIconStyleOption = AppIconStyleOption.THEMED,
     val customColorOption: String? = null,
     val customPrimaryColor: String? = null,
     val customSecondaryColor: String? = null,

--- a/app/src/main/java/com/talauncher/ui/theme/UiSettings.kt
+++ b/app/src/main/java/com/talauncher/ui/theme/UiSettings.kt
@@ -1,6 +1,7 @@
 package com.talauncher.ui.theme
 
 import com.talauncher.data.model.ColorPaletteOption
+import com.talauncher.data.model.AppIconStyleOption
 import com.talauncher.data.model.LauncherSettings
 import com.talauncher.data.model.ThemeModeOption
 import com.talauncher.data.model.UiDensityOption
@@ -13,6 +14,7 @@ import com.talauncher.ui.components.UiDensity
  */
 data class UiSettings(
     val colorPalette: ColorPaletteOption = ColorPaletteOption.DEFAULT,
+    val appIconStyle: AppIconStyleOption = AppIconStyleOption.THEMED,
     val themeMode: ThemeModeOption = ThemeModeOption.SYSTEM,
     val enableGlassmorphism: Boolean = true,
     val enableAnimations: Boolean = true,
@@ -32,6 +34,7 @@ data class UiSettings(
  */
 fun LauncherSettings.toUiSettings(): UiSettings = UiSettings(
     colorPalette = this.colorPalette,
+    appIconStyle = this.appIconStyle,
     themeMode = this.themeMode,
     enableGlassmorphism = this.enableGlassmorphism,
     enableAnimations = this.enableAnimations,

--- a/app/src/test/java/com/talauncher/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/talauncher/SettingsRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.talauncher
 
 import com.talauncher.data.database.SettingsDao
 import com.talauncher.data.model.ColorPaletteOption
+import com.talauncher.data.model.AppIconStyleOption
 import com.talauncher.data.model.LauncherSettings
 import com.talauncher.data.model.UiDensityOption
 import com.talauncher.data.repository.SettingsRepository
@@ -107,6 +108,16 @@ class SettingsRepositoryTest {
         repository.updateColorPalette(ColorPaletteOption.WARM)
 
         verify(settingsDao).updateSettings(check { assertEquals(ColorPaletteOption.WARM, it.colorPalette) })
+    }
+
+    @Test
+    fun `updateAppIconStyle updates icon style`() = runTest {
+        println("Running updateAppIconStyle updates icon style test")
+        whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
+
+        repository.updateAppIconStyle(AppIconStyleOption.ORIGINAL)
+
+        verify(settingsDao).updateSettings(check { assertEquals(AppIconStyleOption.ORIGINAL, it.appIconStyle) })
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add an `AppIconStyleOption` setting with Room migration support and repository/test coverage
- render launcher app rows with left-aligned icons that honor themed, original, or hidden styles
- surface the new icon style picker in settings and propagate selections through view models and UI state

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db767e35188321a22b13655e28c108