### PR TITLE
Rename time limit dialog setting copy

### DIFF
--- a/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
@@ -662,8 +662,8 @@ fun GeneralSettings(
 
 
                     SettingItem(
-                        title = "Time Limit Prompts",
-                        subtitle = "Ask how long you'll use distracting apps",
+                        title = "Time Limit Dialog",
+                        subtitle = "Show a reminder before opening distracting apps",
                         checked = enableTimeLimitPrompt,
                         onCheckedChange = { onToggleTimeLimitPrompt() }
                     )


### PR DESCRIPTION
## Summary
- update the time limit setting label to reflect the dialog shown before opening distracting apps
- refresh the setting description to match the current reminder behavior

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc1fc6f76c8321b00dd9ce0ffa87a3