### PR TITLE
Implement themed icon pipeline

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -140,6 +140,8 @@ dependencies {
     // Material icons extended (for icons like ExpandMore)
     implementation("androidx.compose.material:material-icons-extended")
 
+    implementation("androidx.recyclerview:recyclerview:1.3.2")
+
     // ViewModel
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.4")
 

--- a/app/src/androidTest/java/com/talauncher/icons/IconGridRenderTest.kt
+++ b/app/src/androidTest/java/com/talauncher/icons/IconGridRenderTest.kt
@@ -1,0 +1,70 @@
+package com.talauncher.icons
+
+import android.graphics.Color
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.activity.ComponentActivity
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class IconGridRenderTest {
+
+    @get:Rule
+    val scenarioRule = ActivityScenarioRule(ComponentActivity::class.java)
+
+    @Test
+    fun themedIconsRenderInGrid() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val pm = context.packageManager
+        val installed = pm.getInstalledApplications(0)
+            .takeIf { it.isNotEmpty() }
+            ?.take(12)
+            ?.map { appInfo ->
+                ThemedAppGridItem(
+                    packageName = appInfo.packageName,
+                    label = pm.getApplicationLabel(appInfo).toString()
+                )
+            }
+            ?: run {
+                val fallbackLabel = runCatching {
+                    pm.getApplicationLabel(pm.getApplicationInfo(context.packageName, 0)).toString()
+                }.getOrDefault(context.packageName)
+                listOf(ThemedAppGridItem(context.packageName, fallbackLabel))
+            }
+
+        scenarioRule.scenario.onActivity { activity ->
+            val recyclerView = RecyclerView(activity).apply {
+                layoutParams = FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+                setBackgroundColor(Color.BLACK)
+            }
+            recyclerView.useThemedGrid(columns = 4)
+            val themeColor = Color.parseColor("#FF3B30")
+            val adapter = ThemedAppAdapter(activity, themeColor, (64 * activity.resources.displayMetrics.density).toInt().coerceAtLeast(96))
+            recyclerView.adapter = adapter
+            adapter.submitList(installed)
+            activity.setContentView(recyclerView)
+        }
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        scenarioRule.scenario.onActivity { activity ->
+            val root = activity.findViewById<ViewGroup>(android.R.id.content)
+            val recycler = root.getChildAt(0) as RecyclerView
+            assertTrue("RecyclerView should have themed content", recycler.childCount > 0)
+            val firstHolder = recycler.findViewHolderForAdapterPosition(0) as? ThemedAppAdapter.ViewHolder
+            assertTrue("First holder should contain an icon", firstHolder?.iconView?.drawable != null)
+        }
+    }
+}
+

--- a/app/src/main/java/com/talauncher/icons/IconThemer.kt
+++ b/app/src/main/java/com/talauncher/icons/IconThemer.kt
@@ -1,0 +1,399 @@
+package com.talauncher.icons
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.*
+import android.graphics.drawable.AdaptiveIconDrawable
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.os.Build
+import android.util.LruCache
+import androidx.annotation.ColorInt
+import androidx.annotation.Px
+import androidx.annotation.VisibleForTesting
+import androidx.core.graphics.ColorUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val MIN_CONTRAST_RATIO = 4.5
+private const val BACKGROUND_BLEND_RATIO = 0.75f
+private const val DEFAULT_CORNER_RADIUS_FRACTION = 0.22f
+
+private val iconCache = object : LruCache<String, Bitmap>(32 * 1024) {
+    override fun sizeOf(key: String, value: Bitmap): Int {
+        return value.byteCount / 1024
+    }
+}
+
+/**
+ * Themes an application icon so that the background adopts the provided [themeColor] while the
+ * foreground glyph remains legible across API levels. Work is dispatched off the main thread.
+ */
+suspend fun themeIcon(
+    context: Context,
+    packageName: String,
+    @ColorInt themeColor: Int,
+    @Px sizePx: Int
+): Bitmap = withContext(Dispatchers.Default) {
+    val cacheKey = cacheKey(context, packageName, themeColor, sizePx)
+    iconCache.get(cacheKey)?.let { return@withContext it.copy(it.config, false) }
+
+    val drawable = loadIconDrawable(context, packageName)
+    val bitmap = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && drawable is AdaptiveIconDrawable ->
+            drawMonochromeAwareAdaptive(drawable, themeColor, sizePx)
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && drawable is AdaptiveIconDrawable ->
+            drawAdaptive(drawable, themeColor, sizePx)
+        else ->
+            drawLegacy(drawable, themeColor, sizePx)
+    }
+
+    iconCache.put(cacheKey, bitmap)
+    bitmap.copy(bitmap.config, false)
+}
+
+/** Checks whether the target app exposes a monochrome layer for themed icons on Android 13+. */
+fun supportsMonochrome(context: Context, packageName: String): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
+    val drawable = runCatching { loadIconDrawable(context, packageName) }.getOrNull()
+    return drawable is AdaptiveIconDrawable && drawable.monochrome != null
+}
+
+/**
+ * Ensures the provided foreground color meets the desired contrast ratio against the background.
+ */
+@ColorInt
+fun ensureContrast(
+    @ColorInt fgColor: Int,
+    @ColorInt bgColor: Int,
+    minRatio: Double = MIN_CONTRAST_RATIO
+): Int {
+    if (contrastRatio(fgColor, bgColor) >= minRatio) return fgColor
+
+    val fgHsl = FloatArray(3)
+    ColorUtils.colorToHSL(fgColor, fgHsl)
+    val bgLuminance = ColorUtils.calculateLuminance(bgColor)
+    val targetLightness = if (bgLuminance > 0.5) 0.1f else 0.92f
+    val adjustedHsl = fgHsl.copyOf()
+    adjustedHsl[2] = targetLightness
+    var candidate = ColorUtils.HSLToColor(adjustedHsl)
+
+    if (contrastRatio(candidate, bgColor) >= minRatio) {
+        return candidate
+    }
+
+    val whiteContrast = contrastRatio(Color.WHITE, bgColor)
+    val blackContrast = contrastRatio(Color.BLACK, bgColor)
+    candidate = if (whiteContrast >= blackContrast) Color.WHITE else Color.BLACK
+
+    if (contrastRatio(candidate, bgColor) >= minRatio) {
+        return candidate
+    }
+
+    // As a last resort, lerp between candidate and theme extremes until contrast is met.
+    val extreme = if (bgLuminance > 0.5) Color.BLACK else Color.WHITE
+    var blend = 0.5f
+    repeat(6) {
+        val blended = ColorUtils.blendARGB(candidate, extreme, blend)
+        if (contrastRatio(blended, bgColor) >= minRatio) {
+            return blended
+        }
+        blend = (blend + 1f) / 2f
+    }
+    return candidate
+}
+
+private fun cacheKey(
+    context: Context,
+    packageName: String,
+    @ColorInt themeColor: Int,
+    @Px sizePx: Int
+): String {
+    val nightMode = context.resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK
+    return "$packageName|$themeColor|$sizePx|$nightMode|${Build.VERSION.SDK_INT}"
+}
+
+private fun loadIconDrawable(context: Context, packageName: String): Drawable {
+    val pm = context.packageManager
+    val appInfo = pm.getApplicationInfo(packageName, 0)
+    val density = context.resources.displayMetrics.densityDpi
+    val iconId = appInfo.icon
+    val drawable = if (iconId != 0) {
+        try {
+            pm.getResourcesForApplication(appInfo).getDrawableForDensity(iconId, density, context.theme)
+        } catch (_: PackageManager.NameNotFoundException) {
+            null
+        }
+    } else null
+
+    return (drawable ?: pm.getApplicationIcon(packageName)).mutate()
+}
+
+private fun drawMonochromeAwareAdaptive(
+    drawable: AdaptiveIconDrawable,
+    @ColorInt themeColor: Int,
+    @Px sizePx: Int
+): Bitmap {
+    val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+
+    val clipPath = adaptiveClipPath(sizePx, drawable)
+    canvas.save()
+    canvas.clipPath(clipPath)
+
+    paint.color = themeColor
+    canvas.drawRect(0f, 0f, sizePx.toFloat(), sizePx.toFloat(), paint)
+
+    canvas.restore()
+
+    val foregroundColor = ensureContrast(Color.WHITE, themeColor)
+    val monochrome = drawable.monochrome
+    if (monochrome != null) {
+        val fg = monochrome.mutate()
+        fg.setTint(foregroundColor)
+        fg.setBounds(0, 0, sizePx, sizePx)
+        canvas.save()
+        canvas.clipPath(clipPath)
+        fg.draw(canvas)
+        canvas.restore()
+        return bitmap
+    }
+
+    // Fallback to adaptive drawing if monochrome is absent (should not happen on this path).
+    return drawAdaptive(drawable, themeColor, sizePx)
+}
+
+private fun drawAdaptive(
+    drawable: AdaptiveIconDrawable,
+    @ColorInt themeColor: Int,
+    @Px sizePx: Int
+): Bitmap {
+    val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    val clipPath = adaptiveClipPath(sizePx, drawable)
+
+    canvas.save()
+    canvas.clipPath(clipPath)
+
+    val background = drawable.background?.mutate()
+    if (background != null) {
+        tintDrawable(background, themeColor)
+        background.setBounds(0, 0, sizePx, sizePx)
+        background.draw(canvas)
+    } else {
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = themeColor }
+        canvas.drawRect(0f, 0f, sizePx.toFloat(), sizePx.toFloat(), paint)
+    }
+
+    canvas.restore()
+
+    val foregroundDrawable = drawable.foreground?.mutate()
+    if (foregroundDrawable != null) {
+        val fgBitmap = foregroundDrawable.toBitmap(sizePx)
+        val avgColor = averageOpaqueColor(fgBitmap)
+        val needsContrast = contrastRatio(avgColor, themeColor) < MIN_CONTRAST_RATIO
+        val paint = if (needsContrast) Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            colorFilter = PorterDuffColorFilter(
+                ensureContrast(avgColor, themeColor),
+                PorterDuff.Mode.SRC_ATOP
+            )
+        } else null
+        canvas.save()
+        canvas.clipPath(clipPath)
+        canvas.drawBitmap(fgBitmap, 0f, 0f, paint)
+        canvas.restore()
+    }
+
+    return bitmap
+}
+
+private fun drawLegacy(
+    drawable: Drawable,
+    @ColorInt themeColor: Int,
+    @Px sizePx: Int
+): Bitmap {
+    val baseBitmap = drawable.toBitmap(sizePx)
+    val pixels = IntArray(sizePx * sizePx)
+    baseBitmap.getPixels(pixels, 0, sizePx, 0, 0, sizePx, sizePx)
+
+    val bgColor = estimateBackgroundColor(pixels, sizePx, sizePx)
+    val bgLuminance = ColorUtils.calculateLuminance(bgColor)
+
+    for (i in pixels.indices) {
+        val color = pixels[i]
+        val alpha = Color.alpha(color)
+        if (alpha <= 16) continue
+        val distance = colorDistance(color, bgColor)
+        val lumDiff = kotlin.math.abs(ColorUtils.calculateLuminance(color) - bgLuminance)
+        if (distance < 0.16 && lumDiff < 0.16) {
+            val blended = ColorUtils.blendARGB(bgColor, themeColor, BACKGROUND_BLEND_RATIO)
+            pixels[i] = (alpha shl 24) or (blended and 0x00FFFFFF)
+        } else {
+            val adjusted = ensureContrast(color, themeColor)
+            if (contrastRatio(color, themeColor) < MIN_CONTRAST_RATIO) {
+                val blended = ColorUtils.blendARGB(color, adjusted, 0.6f)
+                pixels[i] = (alpha shl 24) or (blended and 0x00FFFFFF)
+            }
+        }
+    }
+
+    val themedBitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    themedBitmap.setPixels(pixels, 0, sizePx, 0, 0, sizePx, sizePx)
+
+    val masked = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(masked)
+    val maskPath = roundedRectPath(sizePx)
+    val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.WHITE }
+    canvas.drawPath(maskPath, paint)
+    paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
+    canvas.drawBitmap(themedBitmap, 0f, 0f, paint)
+    paint.xfermode = null
+
+    return masked
+}
+
+private fun tintDrawable(drawable: Drawable, @ColorInt color: Int) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        drawable.setTint(color)
+        drawable.setTintMode(PorterDuff.Mode.SRC_IN)
+    } else {
+        @Suppress("DEPRECATION")
+        drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN)
+    }
+}
+
+private fun Drawable.toBitmap(@Px sizePx: Int): Bitmap {
+    if (this is BitmapDrawable && bitmap.width >= sizePx && bitmap.height >= sizePx) {
+        return Bitmap.createScaledBitmap(bitmap, sizePx, sizePx, true)
+    }
+    val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    val oldBounds = bounds
+    setBounds(0, 0, sizePx, sizePx)
+    draw(canvas)
+    setBounds(oldBounds.left, oldBounds.top, oldBounds.right, oldBounds.bottom)
+    return bitmap
+}
+
+private fun averageOpaqueColor(bitmap: Bitmap): Int {
+    val width = bitmap.width
+    val height = bitmap.height
+    var r = 0.0
+    var g = 0.0
+    var b = 0.0
+    var count = 0
+    val pixels = IntArray(width * height)
+    bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+    for (color in pixels) {
+        val alpha = Color.alpha(color)
+        if (alpha < 32) continue
+        r += Color.red(color)
+        g += Color.green(color)
+        b += Color.blue(color)
+        count++
+    }
+    if (count == 0) return Color.WHITE
+    return Color.rgb((r / count).toInt(), (g / count).toInt(), (b / count).toInt())
+}
+
+private fun estimateBackgroundColor(pixels: IntArray, width: Int, height: Int): Int {
+    val samples = mutableListOf<Int>()
+    val stepX = (width / 8).coerceAtLeast(1)
+    val stepY = (height / 8).coerceAtLeast(1)
+    for (x in 0 until width step stepX) {
+        for (y in listOf(0, height - 1)) {
+            val color = pixels[y * width + x]
+            if (Color.alpha(color) > 64) samples.add(color)
+        }
+    }
+    for (y in 0 until height step stepY) {
+        for (x in listOf(0, width - 1)) {
+            val color = pixels[y * width + x]
+            if (Color.alpha(color) > 64) samples.add(color)
+        }
+    }
+    if (samples.isEmpty()) {
+        return ColorUtils.blendARGB(Color.BLACK, Color.WHITE, 0.5f)
+    }
+    var r = 0.0
+    var g = 0.0
+    var b = 0.0
+    for (color in samples) {
+        r += Color.red(color)
+        g += Color.green(color)
+        b += Color.blue(color)
+    }
+    return Color.rgb((r / samples.size).toInt(), (g / samples.size).toInt(), (b / samples.size).toInt())
+}
+
+private fun colorDistance(@ColorInt a: Int, @ColorInt b: Int): Double {
+    val dr = Color.red(a) - Color.red(b)
+    val dg = Color.green(a) - Color.green(b)
+    val db = Color.blue(a) - Color.blue(b)
+    return kotlin.math.sqrt((dr * dr + dg * dg + db * db).toDouble()) / 441.6729559300637
+}
+
+private fun adaptiveClipPath(@Px sizePx: Int, drawable: AdaptiveIconDrawable): Path {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        val mask = Path(drawable.iconMask)
+        val bounds = RectF()
+        mask.computeBounds(bounds, true)
+        val matrix = Matrix()
+        val scaleX = sizePx / bounds.width()
+        val scaleY = sizePx / bounds.height()
+        matrix.setScale(scaleX, scaleY)
+        matrix.postTranslate(-bounds.left * scaleX, -bounds.top * scaleY)
+        mask.transform(matrix)
+        mask
+    } else {
+        roundedRectPath(sizePx)
+    }
+}
+
+private fun roundedRectPath(@Px sizePx: Int): Path {
+    val radius = sizePx * DEFAULT_CORNER_RADIUS_FRACTION
+    return Path().apply {
+        addRoundRect(
+            RectF(0f, 0f, sizePx.toFloat(), sizePx.toFloat()),
+            radius,
+            radius,
+            Path.Direction.CW
+        )
+    }
+}
+
+@VisibleForTesting
+internal fun themeDrawableForTesting(
+    drawable: Drawable,
+    @ColorInt themeColor: Int,
+    @Px sizePx: Int
+): Bitmap {
+    return when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && drawable is AdaptiveIconDrawable && drawable.monochrome != null ->
+            drawMonochromeAwareAdaptive(drawable, themeColor, sizePx)
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && drawable is AdaptiveIconDrawable ->
+            drawAdaptive(drawable, themeColor, sizePx)
+        else ->
+            drawLegacy(drawable, themeColor, sizePx)
+    }
+}
+
+fun relativeLuminance(@ColorInt color: Int): Double {
+    val r = Color.red(color) / 255.0
+    val g = Color.green(color) / 255.0
+    val b = Color.blue(color) / 255.0
+    val rLin = if (r <= 0.03928) r / 12.92 else Math.pow((r + 0.055) / 1.055, 2.4)
+    val gLin = if (g <= 0.03928) g / 12.92 else Math.pow((g + 0.055) / 1.055, 2.4)
+    val bLin = if (b <= 0.03928) b / 12.92 else Math.pow((b + 0.055) / 1.055, 2.4)
+    return 0.2126 * rLin + 0.7152 * gLin + 0.0722 * bLin
+}
+
+fun contrastRatio(@ColorInt a: Int, @ColorInt b: Int): Double {
+    val l1 = relativeLuminance(a)
+    val l2 = relativeLuminance(b)
+    val light = maxOf(l1, l2)
+    val dark = minOf(l1, l2)
+    return (light + 0.05) / (dark + 0.05)
+}
+

--- a/app/src/main/java/com/talauncher/icons/ThemedAppAdapter.kt
+++ b/app/src/main/java/com/talauncher/icons/ThemedAppAdapter.kt
@@ -1,0 +1,157 @@
+package com.talauncher.icons
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.view.Gravity
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.annotation.ColorInt
+import androidx.annotation.Px
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Simple RecyclerView adapter demonstrating how to consume [themeIcon] inside a launcher grid.
+ */
+class ThemedAppAdapter(
+    private val context: Context,
+    @ColorInt themeColor: Int,
+    @Px private val iconSizePx: Int,
+    scope: CoroutineScope? = null
+) : RecyclerView.Adapter<ThemedAppAdapter.ViewHolder>() {
+
+    private var items: List<ThemedAppGridItem> = emptyList()
+    private var currentThemeColor: Int = themeColor
+    private var iconScope: CoroutineScope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val ownsScope: Boolean = scope == null
+
+    class ViewHolder(container: FrameLayout) : RecyclerView.ViewHolder(container) {
+        val iconView: ImageView = ImageView(container.context).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            ).apply {
+                gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+            }
+            adjustViewBounds = true
+            scaleType = ImageView.ScaleType.FIT_CENTER
+            isClickable = false
+            isFocusable = false
+        }
+        val labelView: TextView = TextView(container.context).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            ).apply {
+                gravity = Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+            }
+            gravity = Gravity.CENTER
+            setTextColor(Color.WHITE)
+            textSize = 12f
+            isClickable = false
+            isFocusable = false
+        }
+        var loadJob: Job? = null
+
+        init {
+            container.addView(iconView)
+            container.addView(labelView)
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val layoutParams = RecyclerView.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+        val frame = FrameLayout(parent.context).apply {
+            this.layoutParams = layoutParams
+            minimumHeight = (iconSizePx * 1.35f).toInt()
+            setPadding(0, (iconSizePx * 0.08f).toInt(), 0, (iconSizePx * 0.2f).toInt())
+        }
+        return ViewHolder(frame)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = items[position]
+        holder.labelView.text = item.label
+        holder.labelView.contentDescription = item.label
+        holder.labelView.setTextColor(ensureContrast(holder.labelView.currentTextColor, currentThemeColor))
+        holder.iconView.layoutParams = (holder.iconView.layoutParams as FrameLayout.LayoutParams).apply {
+            width = iconSizePx
+            height = iconSizePx
+        }
+        holder.iconView.setImageDrawable(null)
+        holder.loadJob?.cancel()
+        holder.loadJob = iconScope.launch {
+            val themedBitmap: Bitmap = themeIcon(context, item.packageName, currentThemeColor, iconSizePx)
+            withContext(Dispatchers.Main) {
+                holder.iconView.setImageBitmap(themedBitmap)
+                holder.iconView.contentDescription = item.label
+            }
+        }
+    }
+
+    override fun onViewRecycled(holder: ViewHolder) {
+        super.onViewRecycled(holder)
+        holder.loadJob?.cancel()
+        holder.loadJob = null
+        holder.iconView.setImageDrawable(null)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun submitList(newItems: List<ThemedAppGridItem>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
+
+    fun updateThemeColor(@ColorInt color: Int) {
+        if (color == currentThemeColor) return
+        currentThemeColor = color
+        notifyDataSetChanged()
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        super.onDetachedFromRecyclerView(recyclerView)
+        if (ownsScope) {
+            iconScope.cancel()
+        }
+    }
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        if (ownsScope && !iconScope.isActive) {
+            iconScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        }
+    }
+}
+
+/** Simple value object representing an item in the grid. */
+data class ThemedAppGridItem(
+    val packageName: String,
+    val label: String
+)
+
+/**
+ * Helper extension for quickly wiring a grid layout to the RecyclerView when using the adapter
+ * from Compose interop or activities.
+ */
+fun RecyclerView.useThemedGrid(columns: Int = 4) {
+    if (layoutManager !is GridLayoutManager) {
+        layoutManager = GridLayoutManager(context, columns)
+    }
+    setHasFixedSize(true)
+}
+

--- a/app/src/test/java/com/talauncher/icons/IconThemerTest.kt
+++ b/app/src/test/java/com/talauncher/icons/IconThemerTest.kt
@@ -1,0 +1,54 @@
+package com.talauncher.icons
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import androidx.annotation.ColorInt
+import androidx.core.graphics.ColorUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class IconThemerTest {
+
+    @Test
+    fun `ensureContrast enforces minimum contrast`() {
+        val background = Color.parseColor("#AA0000")
+        val foreground = Color.parseColor("#880000")
+        val adjusted = ensureContrast(foreground, background)
+        val ratio = contrastRatio(adjusted, background)
+        assertTrue("Contrast ratio should be >= 4.5 but was $ratio", ratio >= 4.5)
+    }
+
+    @Test
+    fun `relativeLuminance matches known values`() {
+        assertEquals(0.0, relativeLuminance(Color.BLACK), 0.0001)
+        assertEquals(1.0, relativeLuminance(Color.WHITE), 0.0001)
+        val mid = relativeLuminance(Color.GRAY)
+        assertTrue(mid in 0.2..0.6)
+    }
+
+    @Test
+    @Config(sdk = [28])
+    fun `legacy drawable backgrounds adopt theme`() {
+        val drawable = ColorDrawable(Color.BLUE)
+        val themeColor = Color.RED
+        val bitmap: Bitmap = themeDrawableForTesting(drawable, themeColor, 96)
+        val center = bitmap.getPixel(bitmap.width / 2, bitmap.height / 2)
+        val expected = ColorUtils.blendARGB(Color.BLUE, themeColor, 0.75f)
+        val distance = colorDistance(center, expected)
+        assertTrue("Center pixel should be close to blended theme color", distance < 0.12)
+    }
+
+    private fun colorDistance(@ColorInt a: Int, @ColorInt b: Int): Double {
+        val dr = Color.red(a) - Color.red(b)
+        val dg = Color.green(a) - Color.green(b)
+        val db = Color.blue(a) - Color.blue(b)
+        return Math.sqrt((dr * dr + dg * dg + db * db).toDouble()) / 441.6729559300637
+    }
+}
+


### PR DESCRIPTION
## Summary
- add an IconThemer utility that recolors adaptive and legacy icons with caching, WCAG contrast checks, and multi-API fallbacks
- provide a RecyclerView grid adapter example that themes icons asynchronously and supports dynamic theme updates
- extend tests with Robolectric coverage for contrast math plus an instrumentation smoke test, and include RecyclerView dependency

## Testing
- ./gradlew test *(fails: Android SDK not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2f9290d483219374b5cede08d515