### PR TITLE
Remove timed session expiry handling

### DIFF
--- a/app/src/main/java/com/talauncher/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/SessionRepository.kt
@@ -2,56 +2,14 @@ package com.talauncher.data.repository
 
 import com.talauncher.data.database.AppSessionDao
 import com.talauncher.data.model.AppSession
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 
 class SessionRepository(private val appSessionDao: AppSessionDao) {
 
-    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    private val expirationEvents = MutableSharedFlow<AppSession>(extraBufferCapacity = 16)
-    private val expirationJobs = mutableMapOf<Long, Job>()
-    private val jobsMutex = Mutex()
-
-    suspend fun cleanup() {
-        jobsMutex.withLock {
-            expirationJobs.values.forEach { it.cancel() }
-            expirationJobs.clear()
-        }
-    }
-
     fun getActiveSessions(): Flow<List<AppSession>> = appSessionDao.getActiveSessions()
-
-    suspend fun initialize() {
-        val activeSessions = appSessionDao.getActiveSessions().first()
-        activeSessions.forEach { scheduleExpiration(it) }
-    }
-
-    fun observeSessionExpirations(): SharedFlow<AppSession> = expirationEvents.asSharedFlow()
-
-    suspend fun emitExpiredSessions() {
-        val activeSessions = appSessionDao.getActiveSessions().first()
-        activeSessions.filter { isSessionExpired(it) }.forEach { triggerExpiration(it) }
-    }
 
     suspend fun getActiveSessionForApp(packageName: String): AppSession? =
         appSessionDao.getActiveSessionForApp(packageName)
-
-    suspend fun getExpiredSessions(): List<AppSession> {
-        val activeSessions = appSessionDao.getActiveSessions().first()
-        return activeSessions.filter { isSessionExpired(it) }
-    }
 
     suspend fun startSession(packageName: String, plannedDurationMinutes: Int): Long {
         appSessionDao.getActiveSessionForApp(packageName)?.let { endSession(it.id) }
@@ -63,12 +21,10 @@ class SessionRepository(private val appSessionDao: AppSessionDao) {
             isActive = true
         )
         val sessionId = appSessionDao.insertSession(session)
-        scheduleExpiration(session.copy(id = sessionId))
         return sessionId
     }
 
     suspend fun endSession(sessionId: Long) {
-        cancelExpirationJob(sessionId)
         appSessionDao.endSession(sessionId, System.currentTimeMillis())
     }
 
@@ -81,57 +37,6 @@ class SessionRepository(private val appSessionDao: AppSessionDao) {
     suspend fun cleanupOldSessions() {
         val cutoffTime = System.currentTimeMillis() - (7 * 24 * 60 * 60 * 1000L) // 7 days ago
         appSessionDao.deleteOldSessions(cutoffTime)
-    }
-
-    fun isSessionExpired(session: AppSession): Boolean {
-        val currentTime = System.currentTimeMillis()
-        val sessionDuration = currentTime - session.startTime
-        val plannedDuration = session.plannedDurationMinutes * 60 * 1000L
-        return sessionDuration >= plannedDuration
-    }
-
-    fun getRemainingTime(session: AppSession): Long {
-        val currentTime = System.currentTimeMillis()
-        val sessionDuration = currentTime - session.startTime
-        val plannedDuration = session.plannedDurationMinutes * 60 * 1000L
-        return maxOf(0, plannedDuration - sessionDuration)
-    }
-
-    private fun scheduleExpiration(session: AppSession) {
-        coroutineScope.launch {
-            cancelExpirationJob(session.id)
-            val job = coroutineScope.launch {
-                val remainingTime = getRemainingTime(session)
-                if (remainingTime > 0) {
-                    delay(remainingTime)
-                }
-                triggerExpiration(session)
-            }
-            jobsMutex.withLock {
-                expirationJobs[session.id] = job
-            }
-        }
-    }
-
-    private suspend fun triggerExpiration(session: AppSession) {
-        var sessionForEvent: AppSession? = null
-        withContext(Dispatchers.IO) {
-            val activeSession = appSessionDao.getActiveSessionForApp(session.packageName)
-            if (activeSession?.id == session.id && activeSession.isActive) {
-                val endTime = System.currentTimeMillis()
-                // End session first to prevent race conditions
-                appSessionDao.endSession(session.id, endTime)
-                sessionForEvent = activeSession.copy(isActive = false, endTime = endTime)
-            }
-        }
-        cancelExpirationJob(session.id)
-        sessionForEvent?.let { expirationEvents.emit(it) }
-    }
-
-    private suspend fun cancelExpirationJob(sessionId: Long) {
-        jobsMutex.withLock {
-            expirationJobs.remove(sessionId)?.cancel()
-        }
     }
 }
 

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -145,12 +145,6 @@ fun HomeScreen(
         }
     }
 
-    // Check for expired sessions when home screen is displayed
-    LaunchedEffect(Unit) {
-        viewModel.checkExpiredSessionsManually()
-    }
-
-
     // Use modern backdrop with new design system
     ModernBackdrop(
         showWallpaper = uiState.showWallpaper,

--- a/app/src/test/java/com/talauncher/EdgeCaseAndErrorHandlingTest.kt
+++ b/app/src/test/java/com/talauncher/EdgeCaseAndErrorHandlingTest.kt
@@ -4,10 +4,8 @@ import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import com.talauncher.data.model.AppInfo
-import com.talauncher.data.model.AppSession
 import com.talauncher.data.model.LauncherSettings
 import com.talauncher.data.repository.AppRepository
-import com.talauncher.data.repository.SessionRepository
 import com.talauncher.data.repository.SettingsRepository
 import com.talauncher.ui.home.HomeViewModel
 import com.talauncher.utils.ErrorHandler
@@ -16,9 +14,7 @@ import com.talauncher.utils.PermissionsHelper
 import com.talauncher.utils.UsageStatsHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -52,9 +48,6 @@ class EdgeCaseAndErrorHandlingTest {
     private lateinit var settingsRepository: SettingsRepository
 
     @Mock
-    private lateinit var sessionRepository: SessionRepository
-
-    @Mock
     private lateinit var permissionsHelper: PermissionsHelper
 
     @Mock
@@ -82,7 +75,6 @@ class EdgeCaseAndErrorHandlingTest {
         whenever(appRepository.getAllVisibleApps()).thenReturn(flowOf(emptyList()))
         whenever(appRepository.getHiddenApps()).thenReturn(flowOf(emptyList()))
         whenever(settingsRepository.getSettings()).thenReturn(flowOf(null))
-        whenever(sessionRepository.observeSessionExpirations()).thenReturn(MutableSharedFlow<AppSession>().asSharedFlow())
         whenever(permissionsHelper.permissionState).thenReturn(MutableStateFlow(PermissionState()))
         whenever(usageStatsHelper.getPast48HoursUsageStats(any())).thenReturn(emptyList())
 
@@ -90,7 +82,6 @@ class EdgeCaseAndErrorHandlingTest {
         val viewModel = HomeViewModel(
             appRepository = appRepository,
             settingsRepository = settingsRepository,
-            sessionRepository = sessionRepository,
             appContext = appContext,
             permissionsHelper = permissionsHelper,
             usageStatsHelper = usageStatsHelper,

--- a/app/src/test/java/com/talauncher/HomeViewModelTest.kt
+++ b/app/src/test/java/com/talauncher/HomeViewModelTest.kt
@@ -4,10 +4,8 @@ import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import com.talauncher.data.model.AppInfo
-import com.talauncher.data.model.AppSession
 import com.talauncher.data.model.LauncherSettings
 import com.talauncher.data.repository.AppRepository
-import com.talauncher.data.repository.SessionRepository
 import com.talauncher.data.repository.SettingsRepository
 import com.talauncher.ui.home.HomeViewModel
 import com.talauncher.utils.ErrorHandler
@@ -16,9 +14,7 @@ import com.talauncher.utils.PermissionsHelper
 import com.talauncher.utils.UsageStatsHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -53,9 +49,6 @@ class HomeViewModelTest {
     private lateinit var settingsRepository: SettingsRepository
 
     @Mock
-    private lateinit var sessionRepository: SessionRepository
-
-    @Mock
     private lateinit var permissionsHelper: PermissionsHelper
 
     @Mock
@@ -76,8 +69,6 @@ class HomeViewModelTest {
         whenever(settingsRepository.getSettings()).thenReturn(flowOf(LauncherSettings()))
         whenever(appRepository.getAllVisibleApps()).thenReturn(flowOf(emptyList()))
         whenever(appRepository.getHiddenApps()).thenReturn(flowOf(emptyList()))
-        whenever(sessionRepository.observeSessionExpirations()).thenReturn(MutableSharedFlow<AppSession>().asSharedFlow())
-        runBlocking { whenever(sessionRepository.emitExpiredSessions()).thenReturn(Unit) }
         whenever(permissionsHelper.permissionState).thenReturn(MutableStateFlow(PermissionState()))
         runBlocking { whenever(usageStatsHelper.getPast48HoursUsageStats(any())).thenReturn(emptyList()) }
     }
@@ -100,7 +91,6 @@ class HomeViewModelTest {
         viewModel = HomeViewModel(
             appRepository = appRepository,
             settingsRepository = settingsRepository,
-            sessionRepository = sessionRepository,
             appContext = appContext,
             permissionsHelper = permissionsHelper,
             usageStatsHelper = usageStatsHelper,


### PR DESCRIPTION
## Summary
- remove the coroutine-based session expiration scheduling from SessionRepository
- stop the activity and home view model from emitting or responding to session expiry events
- update the home screen and unit tests to reflect the removal of timed expiry logic

## Testing
- ./gradlew test *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc31174f80832193af0c907182eefe