### PR TITLE
Allow HomeViewModel weather helper injection in tests

### DIFF
--- a/app/src/main/java/com/talauncher/service/WeatherService.kt
+++ b/app/src/main/java/com/talauncher/service/WeatherService.kt
@@ -15,9 +15,9 @@ import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
 
-class WeatherService(private val context: Context) {
+open class WeatherService(private val context: Context) {
 
-    suspend fun getCurrentWeather(lat: Double, lon: Double): Result<WeatherData> {
+    open suspend fun getCurrentWeather(lat: Double, lon: Double): Result<WeatherData> {
         return withContext(Dispatchers.IO) {
             try {
                 val url = "https://api.open-meteo.com/v1/forecast?latitude=$lat&longitude=$lon&current=temperature_2m,weather_code,is_day&timezone=auto"
@@ -41,7 +41,7 @@ class WeatherService(private val context: Context) {
         }
     }
 
-    suspend fun getHourlyWeather(lat: Double, lon: Double): Result<List<WeatherHourly>> {
+    open suspend fun getHourlyWeather(lat: Double, lon: Double): Result<List<WeatherHourly>> {
         return withContext(Dispatchers.IO) {
             try {
                 val url = "https://api.open-meteo.com/v1/forecast?latitude=$lat&longitude=$lon&hourly=temperature_2m,weather_code,is_day&timezone=auto&forecast_days=1"
@@ -72,7 +72,7 @@ class WeatherService(private val context: Context) {
         }
     }
 
-    suspend fun getDailyWeather(lat: Double, lon: Double): Result<List<WeatherDaily>> {
+    open suspend fun getDailyWeather(lat: Double, lon: Double): Result<List<WeatherDaily>> {
         return withContext(Dispatchers.IO) {
             try {
                 val url = "https://api.open-meteo.com/v1/forecast?latitude=$lat&longitude=$lon&daily=temperature_2m_max,temperature_2m_min,weather_code&timezone=auto&forecast_days=7"
@@ -103,7 +103,7 @@ class WeatherService(private val context: Context) {
         }
     }
 
-    suspend fun getCurrentLocation(): Pair<Double, Double>? = withContext(Dispatchers.IO) {
+    open suspend fun getCurrentLocation(): Pair<Double, Double>? = withContext(Dispatchers.IO) {
         val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
 
         try {

--- a/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
@@ -88,6 +88,12 @@ sealed interface HomeEvent {
     data object RequestContactsPermission : HomeEvent
 }
 
+/**
+ * ViewModel backing the minimalist home experience.
+ *
+ * @param weatherService Allows injecting a fake implementation in tests so they can avoid
+ * hitting the network while exercising unrelated functionality.
+ */
 class HomeViewModel(
     private val appRepository: AppRepository,
     private val settingsRepository: SettingsRepository,
@@ -95,6 +101,7 @@ class HomeViewModel(
     private val onLaunchApp: ((String, Int?) -> Unit)? = null,
     private val sessionRepository: SessionRepository? = null,
     private val appContext: Context,
+    private val weatherService: WeatherService = WeatherService(appContext),
     initialContactHelper: ContactHelper? = null,
     private val permissionsHelper: PermissionsHelper? = null,
     private val usageStatsHelper: UsageStatsHelper? = null,
@@ -110,7 +117,6 @@ class HomeViewModel(
     private val contactHelper: ContactHelper? = initialContactHelper ?: permissionsHelper?.let {
         ContactHelper(appContext, it)
     }
-    private val weatherService = WeatherService(appContext)
     private val fallbackPermissionsHelper: PermissionsHelper by lazy { PermissionsHelper(appContext) }
     private val resolvedPermissionsHelper: PermissionsHelper?
         get() = permissionsHelper ?: fallbackPermissionsHelper

--- a/app/src/test/java/com/talauncher/EdgeCaseAndErrorHandlingTest.kt
+++ b/app/src/test/java/com/talauncher/EdgeCaseAndErrorHandlingTest.kt
@@ -87,11 +87,13 @@ class EdgeCaseAndErrorHandlingTest {
         whenever(usageStatsHelper.getPast48HoursUsageStats(any())).thenReturn(emptyList())
 
         val appContext = ApplicationProvider.getApplicationContext<Context>()
+        // Inject the fake weather helper so this test stays offline and deterministic.
         val viewModel = HomeViewModel(
             appRepository = appRepository,
             settingsRepository = settingsRepository,
             sessionRepository = sessionRepository,
             appContext = appContext,
+            weatherService = FakeWeatherService(appContext),
             permissionsHelper = permissionsHelper,
             usageStatsHelper = usageStatsHelper,
             errorHandler = errorHandler

--- a/app/src/test/java/com/talauncher/FakeWeatherService.kt
+++ b/app/src/test/java/com/talauncher/FakeWeatherService.kt
@@ -1,0 +1,23 @@
+package com.talauncher
+
+import android.content.Context
+import com.talauncher.data.model.WeatherDaily
+import com.talauncher.data.model.WeatherData
+import com.talauncher.data.model.WeatherHourly
+import com.talauncher.service.WeatherService
+
+/**
+ * Lightweight weather helper used in tests so they do not make real HTTP calls.
+ */
+class FakeWeatherService(context: Context) : WeatherService(context) {
+    override suspend fun getCurrentWeather(lat: Double, lon: Double): Result<WeatherData> =
+        Result.success(WeatherData(temperature = 0.0, weatherCode = 0, isDay = true))
+
+    override suspend fun getHourlyWeather(lat: Double, lon: Double): Result<List<WeatherHourly>> =
+        Result.success(emptyList())
+
+    override suspend fun getDailyWeather(lat: Double, lon: Double): Result<List<WeatherDaily>> =
+        Result.success(emptyList())
+
+    override suspend fun getCurrentLocation(): Pair<Double, Double>? = null
+}

--- a/app/src/test/java/com/talauncher/HomeViewModelTest.kt
+++ b/app/src/test/java/com/talauncher/HomeViewModelTest.kt
@@ -97,11 +97,13 @@ class HomeViewModelTest {
         whenever(appRepository.getAllVisibleApps()).thenReturn(flowOf(visibleApps))
 
         val appContext = ApplicationProvider.getApplicationContext<Context>()
+        // Inject the fake weather helper so this test stays offline and deterministic.
         viewModel = HomeViewModel(
             appRepository = appRepository,
             settingsRepository = settingsRepository,
             sessionRepository = sessionRepository,
             appContext = appContext,
+            weatherService = FakeWeatherService(appContext),
             permissionsHelper = permissionsHelper,
             usageStatsHelper = usageStatsHelper,
             errorHandler = errorHandler


### PR DESCRIPTION
## Summary
- make `WeatherService` subclassable and inject it into `HomeViewModel` with a production default
- add a lightweight `FakeWeatherService` for unit tests and document the new injection point
- update existing HomeViewModel unit tests to use the fake helper to avoid network calls

## Testing
- `./gradlew :app:testDebugUnitTest --tests com.talauncher.HomeViewModelTest` *(fails: Android SDK is not available in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68dc34a9eb7c8321ba965a0eddfd5073