### PR TITLE
fix(theme): Use onSurface color for themed icons

### DIFF
--- a/app/src/main/java/com/talauncher/ui/components/ModernComponents.kt
+++ b/app/src/main/java/com/talauncher/ui/components/ModernComponents.kt
@@ -417,7 +417,7 @@ fun AppIcon(
         appName.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
     }
 
-    val tintedColor = MaterialTheme.colorScheme.primary
+    val tintedColor = MaterialTheme.colorScheme.onSurface
     val baseModifier = modifier.size(iconSize)
 
     if (iconBitmap != null) {
@@ -436,7 +436,7 @@ fun AppIcon(
         )
     } else {
         val backgroundColor = when (iconStyle) {
-            AppIconStyleOption.THEMED -> MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+            AppIconStyleOption.THEMED -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
             AppIconStyleOption.ORIGINAL -> MaterialTheme.colorScheme.surfaceVariant
             AppIconStyleOption.HIDDEN -> MaterialTheme.colorScheme.surfaceVariant
         }


### PR DESCRIPTION
Themed icons were using the primary color, which caused contrast issues in some themes. This change updates the themed icons to use the onSurface color, which ensures that they are always visible against the background.