### PR TITLE
Remove Robolectric runner from pure unit tests

### DIFF
--- a/app/src/test/java/com/talauncher/AppDrawerViewModelTest.kt
+++ b/app/src/test/java/com/talauncher/AppDrawerViewModelTest.kt
@@ -26,7 +26,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
@@ -34,11 +33,9 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
-import org.robolectric.RobolectricTestRunner
 import org.junit.Assert.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
 class AppDrawerViewModelTest {
 
     @get:Rule

--- a/app/src/test/java/com/talauncher/AppRepositoryTest.kt
+++ b/app/src/test/java/com/talauncher/AppRepositoryTest.kt
@@ -16,17 +16,14 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.robolectric.RobolectricTestRunner
 import org.junit.Assert.assertEquals
 
-@RunWith(RobolectricTestRunner::class)
 class AppRepositoryTest {
 
     @Mock

--- a/app/src/test/java/com/talauncher/MainViewModelTest.kt
+++ b/app/src/test/java/com/talauncher/MainViewModelTest.kt
@@ -19,16 +19,13 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.whenever
-import org.robolectric.RobolectricTestRunner
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
 class MainViewModelTest {
 
     @get:Rule

--- a/app/src/test/java/com/talauncher/OnboardingViewModelTest.kt
+++ b/app/src/test/java/com/talauncher/OnboardingViewModelTest.kt
@@ -10,15 +10,12 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.*
-import org.robolectric.RobolectricTestRunner
 import org.junit.Assert.*
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
 class OnboardingViewModelTest {
 
     @get:Rule

--- a/app/src/test/java/com/talauncher/PermissionsHelperTest.kt
+++ b/app/src/test/java/com/talauncher/PermissionsHelperTest.kt
@@ -8,14 +8,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.*
-import org.robolectric.RobolectricTestRunner
 import org.junit.Assert.*
 
-@RunWith(RobolectricTestRunner::class)
 class PermissionsHelperTest {
 
     @Mock

--- a/app/src/test/java/com/talauncher/SessionRepositoryTest.kt
+++ b/app/src/test/java/com/talauncher/SessionRepositoryTest.kt
@@ -8,14 +8,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.*
-import org.robolectric.RobolectricTestRunner
 import org.junit.Assert.*
 
-@RunWith(RobolectricTestRunner::class)
 class SessionRepositoryTest {
 
     @Mock

--- a/app/src/test/java/com/talauncher/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/talauncher/SettingsRepositoryTest.kt
@@ -12,17 +12,14 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.robolectric.RobolectricTestRunner
 import org.junit.Assert.assertEquals
 
-@RunWith(RobolectricTestRunner::class)
 class SettingsRepositoryTest {
 
     @Mock


### PR DESCRIPTION
## Summary
- drop the Robolectric test runner from unit tests that only rely on Mockito-based Android stubs
- keep tests relying on Robolectric shadows unchanged

## Testing
- ./gradlew app:testDebugUnitTest *(fails: SDK location not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd04cf26288321ab28415eb57e3543