### PR TITLE
Remove println logging from unit tests

### DIFF
--- a/app/src/test/java/com/talauncher/AppDrawerViewModelTest.kt
+++ b/app/src/test/java/com/talauncher/AppDrawerViewModelTest.kt
@@ -94,7 +94,6 @@ class AppDrawerViewModelTest {
 
     @Test
     fun `initial state loads all apps`() = runTest {
-        println("Running initial state loads all apps test")
         viewModel = AppDrawerViewModel(
             appRepository,
             settingsRepository,
@@ -113,7 +112,6 @@ class AppDrawerViewModelTest {
 
     @Test
     fun `launch app calls repository with correct package name`() = runTest {
-        println("Running launch app calls repository with correct package name test")
         whenever(appRepository.shouldShowTimeLimitPrompt(any())).thenReturn(false)
         whenever(appRepository.launchApp(any(), eq(false), isNull())).thenReturn(true)
 

--- a/app/src/test/java/com/talauncher/AppRepositoryTest.kt
+++ b/app/src/test/java/com/talauncher/AppRepositoryTest.kt
@@ -65,7 +65,6 @@ class AppRepositoryTest {
 
     @Test
     fun `getAllVisibleApps returns filtered apps`() = runTest {
-        println("Running getAllVisibleApps returns filtered apps test")
         val mockApps = listOf(
             createMockApp("com.test.app1", "Test App 1"),
             createMockApp("com.test.app2", "Test App 2")
@@ -79,7 +78,6 @@ class AppRepositoryTest {
 
     @Test
     fun `hideApp marks existing app as hidden`() = runTest {
-        println("Running hideApp marks existing app as hidden test")
         val packageName = "com.test.existing"
         val existingApp = createMockApp(packageName, "Existing App")
 

--- a/app/src/test/java/com/talauncher/EdgeCaseAndErrorHandlingTest.kt
+++ b/app/src/test/java/com/talauncher/EdgeCaseAndErrorHandlingTest.kt
@@ -71,7 +71,6 @@ class EdgeCaseAndErrorHandlingTest {
 
     @Test
     fun `home view model falls back to empty state when data sources return nothing`() = runTest {
-        println("Running home view model falls back to empty state when data sources return nothing test")
         whenever(appRepository.getAllVisibleApps()).thenReturn(flowOf(emptyList()))
         whenever(appRepository.getHiddenApps()).thenReturn(flowOf(emptyList()))
         whenever(settingsRepository.getSettings()).thenReturn(flowOf(null))

--- a/app/src/test/java/com/talauncher/HomeViewModelTest.kt
+++ b/app/src/test/java/com/talauncher/HomeViewModelTest.kt
@@ -80,7 +80,6 @@ class HomeViewModelTest {
 
     @Test
     fun `all visible apps load correctly`() = runTest {
-        println("Running all visible apps load correctly test")
         val visibleApps = listOf(
             AppInfo("com.test.app1", "App 1"),
             AppInfo("com.test.app2", "App 2")

--- a/app/src/test/java/com/talauncher/MainViewModelTest.kt
+++ b/app/src/test/java/com/talauncher/MainViewModelTest.kt
@@ -58,7 +58,6 @@ class MainViewModelTest {
 
     @Test
     fun `initial state is loading`() {
-        println("Running initial state is loading test")
         viewModel = MainViewModel(settingsRepository, appRepository)
 
         assertTrue(viewModel.uiState.value.isLoading)
@@ -67,7 +66,6 @@ class MainViewModelTest {
 
     @Test
     fun `loading completes when settings are loaded`() = runTest {
-        println("Running loading completes when settings are loaded test")
         whenever(settingsRepository.getSettings()).thenReturn(flowOf(LauncherSettings(isOnboardingCompleted = true)))
 
         viewModel = MainViewModel(settingsRepository, appRepository)
@@ -79,7 +77,6 @@ class MainViewModelTest {
 
     @Test
     fun `onboarding not completed shows onboarding flow`() = runTest {
-        println("Running onboarding not completed shows onboarding flow test")
         whenever(settingsRepository.getSettings()).thenReturn(flowOf(LauncherSettings(isOnboardingCompleted = false)))
 
         viewModel = MainViewModel(settingsRepository, appRepository)
@@ -91,7 +88,6 @@ class MainViewModelTest {
 
     @Test
     fun `onOnboardingCompleted updates ui state`() = runTest {
-        println("Running onOnboardingCompleted updates ui state test")
         viewModel = MainViewModel(settingsRepository, appRepository)
 
         viewModel.onOnboardingCompleted()

--- a/app/src/test/java/com/talauncher/OnboardingViewModelTest.kt
+++ b/app/src/test/java/com/talauncher/OnboardingViewModelTest.kt
@@ -43,7 +43,6 @@ class OnboardingViewModelTest {
 
     @Test
     fun `complete onboarding updates settings`() = runTest {
-        println("Running complete onboarding updates settings test")
         viewModel = OnboardingViewModel(settingsRepository)
 
         viewModel.completeOnboarding()

--- a/app/src/test/java/com/talauncher/PermissionsHelperTest.kt
+++ b/app/src/test/java/com/talauncher/PermissionsHelperTest.kt
@@ -38,7 +38,6 @@ class PermissionsHelperTest {
 
     @Test
     fun `permissionState reflects usage stats permission`() = runTest {
-        println("Running permissionState reflects usage stats permission test")
         whenever(appOpsManager.checkOpNoThrow(any(), any(), any())).thenReturn(AppOpsManager.MODE_ALLOWED)
 
         permissionsHelper.checkAllPermissions()
@@ -49,7 +48,6 @@ class PermissionsHelperTest {
 
     @Test
     fun `permissionState reflects no usage stats permission`() = runTest {
-        println("Running permissionState reflects no usage stats permission test")
         whenever(appOpsManager.checkOpNoThrow(any(), any(), any())).thenReturn(AppOpsManager.MODE_ERRORED)
 
         permissionsHelper.checkAllPermissions()

--- a/app/src/test/java/com/talauncher/SessionRepositoryTest.kt
+++ b/app/src/test/java/com/talauncher/SessionRepositoryTest.kt
@@ -31,7 +31,6 @@ class SessionRepositoryTest {
 
     @Test
     fun `startSession creates new session`() = runTest {
-        println("Running startSession creates new session test")
         val packageName = "com.test.app"
         val plannedDurationMinutes = 30
 
@@ -50,7 +49,6 @@ class SessionRepositoryTest {
 
     @Test
     fun `endSession updates session`() = runTest {
-        println("Running endSession updates session test")
         val sessionId = 5L
 
         repository.endSession(sessionId)

--- a/app/src/test/java/com/talauncher/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/talauncher/SettingsRepositoryTest.kt
@@ -40,7 +40,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `getSettings returns settings from dao`() = runTest {
-        println("Running getSettings returns settings from dao test")
         val settings = defaultSettings.copy(backgroundColor = "black")
         whenever(settingsDao.getSettings()).thenReturn(flowOf(settings))
 
@@ -51,7 +50,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `getSettingsSync returns settings synchronously`() = runTest {
-        println("Running getSettingsSync returns settings synchronously test")
         whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
 
         val result = repository.getSettingsSync()
@@ -61,7 +59,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `getSettingsSync returns default settings when dao returns null`() = runTest {
-        println("Running getSettingsSync returns default settings when dao returns null test")
         whenever(settingsDao.getSettingsSync()).thenReturn(null)
 
         val result = repository.getSettingsSync()
@@ -72,7 +69,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `updateSettings calls dao update`() = runTest {
-        println("Running updateSettings calls dao update test")
         val newSettings = defaultSettings.copy(enableTimeLimitPrompt = true)
 
         repository.updateSettings(newSettings)
@@ -82,7 +78,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `updateBackgroundColor normalizes value`() = runTest {
-        println("Running updateBackgroundColor normalizes value test")
         whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
 
         repository.updateBackgroundColor("white")
@@ -92,7 +87,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `updateShowWallpaper updates wallpaper visibility`() = runTest {
-        println("Running updateShowWallpaper updates wallpaper visibility test")
         whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
 
         repository.updateShowWallpaper(false)
@@ -102,7 +96,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `updateColorPalette updates color palette`() = runTest {
-        println("Running updateColorPalette updates color palette test")
         whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
 
         repository.updateColorPalette(ColorPaletteOption.WARM)
@@ -112,7 +105,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `updateAppIconStyle updates icon style`() = runTest {
-        println("Running updateAppIconStyle updates icon style test")
         whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
 
         repository.updateAppIconStyle(AppIconStyleOption.ORIGINAL)
@@ -122,7 +114,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `setCustomPalette updates palette and custom colors together`() = runTest {
-        println("Running setCustomPalette updates palette and custom colors together test")
         whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
 
         repository.setCustomPalette(
@@ -144,7 +135,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `updateWallpaperBlurAmount clamps value`() = runTest {
-        println("Running updateWallpaperBlurAmount clamps value test")
         whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
 
         repository.updateWallpaperBlurAmount(1.5f)
@@ -154,7 +144,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `updateGlassmorphism updates glassmorphism`() = runTest {
-        println("Running updateGlassmorphism updates glassmorphism test")
         whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
 
         repository.updateGlassmorphism(true)
@@ -164,7 +153,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `updateUiDensity updates ui density`() = runTest {
-        println("Running updateUiDensity updates ui density test")
         whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
 
         repository.updateUiDensity(UiDensityOption.COMPACT)
@@ -174,7 +162,6 @@ class SettingsRepositoryTest {
 
     @Test
     fun `updateAnimationsEnabled updates animations`() = runTest {
-        println("Running updateAnimationsEnabled updates animations test")
         whenever(settingsDao.getSettingsSync()).thenReturn(defaultSettings)
 
         repository.updateAnimationsEnabled(false)

--- a/app/src/test/java/com/talauncher/UsageStatsHelperTest.kt
+++ b/app/src/test/java/com/talauncher/UsageStatsHelperTest.kt
@@ -31,7 +31,6 @@ class UsageStatsHelperTest {
 
     @Test
     fun `getTodayUsageStats returns empty list when permission not granted`() = runTest {
-        println("Running getTodayUsageStats returns empty list when permission not granted test")
         val usageStats = usageStatsHelper.getTodayUsageStats(false)
         assertTrue(usageStats.isEmpty())
     }


### PR DESCRIPTION
## Summary
- remove println statements from unit tests so method names and test reports provide context

## Testing
- `./gradlew test` *(fails: SDK location not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd04c7c1448321ad1f4314d71162ab