### PR TITLE
Fix black and white palette preview colors

### DIFF
--- a/app/src/main/java/com/talauncher/ui/components/ThemeComponents.kt
+++ b/app/src/main/java/com/talauncher/ui/components/ThemeComponents.kt
@@ -432,6 +432,11 @@ private val palettePreviewColorsMap = mapOf(
         secondary = Color(0xFF6366F1),
         background = Color(0xFFE0F2FE)
     ),
+    ColorPaletteOption.BLACK_AND_WHITE to PalettePreviewColors(
+        primary = Color.Black,
+        secondary = Color.White,
+        background = Color.White
+    ),
     ColorPaletteOption.NATURE to PalettePreviewColors(
         primary = Color(0xFF256B37),
         secondary = Color(0xFF3A7D44),


### PR DESCRIPTION
## Summary
- add explicit preview colors for the black and white palette so it renders in monochrome

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd4671126c83218aa7cba3cf086fa0