### PR TITLE
Update default theme palette to blue and orange

### DIFF
--- a/app/src/main/java/com/talauncher/ui/components/ThemeComponents.kt
+++ b/app/src/main/java/com/talauncher/ui/components/ThemeComponents.kt
@@ -418,8 +418,8 @@ private fun ColorPreview(
  */
 private val palettePreviewColorsMap = mapOf(
     ColorPaletteOption.DEFAULT to PalettePreviewColors(
-        primary = Color(0xFF6366F1),
-        secondary = Color(0xFF06B6D4),
+        primary = Color(0xFF2196F3),
+        secondary = Color(0xFFFF9800),
         background = Color(0xFFFAFAFA)
     ),
     ColorPaletteOption.WARM to PalettePreviewColors(
@@ -458,8 +458,8 @@ private val palettePreviewColorsMap = mapOf(
         background = Color(0xFFFEF2F2)
     ),
     ColorPaletteOption.CUSTOM to PalettePreviewColors(
-        primary = Color(0xFF6366F1),
-        secondary = Color(0xFF8B5CF6),
+        primary = Color(0xFF2196F3),
+        secondary = Color(0xFFFF9800),
         background = Color(0xFFF8F9FA)
     )
 )
@@ -678,8 +678,8 @@ fun AdvancedCustomColorPickerDialog(
 ) {
     if (!isVisible) return
 
-    var selectedPrimaryColor by remember { mutableStateOf(currentPrimaryColor ?: "#6366F1") }
-    var selectedSecondaryColor by remember { mutableStateOf(currentSecondaryColor ?: "#8B5CF6") }
+    var selectedPrimaryColor by remember { mutableStateOf(currentPrimaryColor ?: "#2196F3") }
+    var selectedSecondaryColor by remember { mutableStateOf(currentSecondaryColor ?: "#FF9800") }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -733,7 +733,7 @@ fun AdvancedCustomColorPickerDialog(
                             value = selectedPrimaryColor,
                             onValueChange = { selectedPrimaryColor = it },
                             label = { Text("Hex Color") },
-                            placeholder = { Text("#6366F1") },
+                            placeholder = { Text("#2196F3") },
                             leadingIcon = {
                                 Box(
                                     modifier = Modifier
@@ -771,7 +771,7 @@ fun AdvancedCustomColorPickerDialog(
                             value = selectedSecondaryColor,
                             onValueChange = { selectedSecondaryColor = it },
                             label = { Text("Hex Color") },
-                            placeholder = { Text("#8B5CF6") },
+                            placeholder = { Text("#FF9800") },
                             leadingIcon = {
                                 Box(
                                     modifier = Modifier
@@ -843,9 +843,9 @@ private fun parseHexColorSafe(hexColor: String): Color {
         when (cleanHex.length) {
             6 -> Color(cleanHex.toLong(16) or 0xFF000000)
             8 -> Color(cleanHex.toLong(16))
-            else -> Color(0xFF6366F1) // Default fallback
+            else -> Color(0xFF2196F3) // Default fallback
         }
     } catch (e: NumberFormatException) {
-        Color(0xFF6366F1) // Default fallback
+        Color(0xFF2196F3) // Default fallback
     }
 }

--- a/app/src/main/java/com/talauncher/ui/theme/Color.kt
+++ b/app/src/main/java/com/talauncher/ui/theme/Color.kt
@@ -6,9 +6,9 @@ import androidx.compose.ui.graphics.Color
 // Inspired by Material Design 3 and contemporary minimalist trends
 
 // Core minimalist colors - sophisticated and refined
-val MinimalPrimary = Color(0xFF1a1a1a)        // Deep charcoal
-val MinimalSecondary = Color(0xFF6366f1)      // Modern indigo
-val MinimalAccent = Color(0xFF06b6d4)         // Cyan accent
+val MinimalPrimary = Color(0xFF2196F3)        // Vibrant blue
+val MinimalSecondary = Color(0xFFFF9800)      // Warm orange
+val MinimalAccent = MinimalSecondary          // Secondary accent
 val MinimalNeutral900 = Color(0xFF111827)     // Almost black
 val MinimalNeutral800 = Color(0xFF1f2937)     // Dark slate
 val MinimalNeutral700 = Color(0xFF374151)     // Slate
@@ -21,13 +21,13 @@ val MinimalNeutral100 = Color(0xFFf3f4f6)     // Off white
 val MinimalNeutral50 = Color(0xFFf9fafb)      // Pure white base
 
 // Light theme colors - clean and airy
-val MinimalPrimaryLight = Color(0xFF6366f1)   // Indigo primary
+val MinimalPrimaryLight = Color(0xFF2196F3)   // Blue primary
 val MinimalSurfaceLight = Color(0xFFffffff)   // Pure white
 val MinimalBackgroundLight = Color(0xFFfafafa) // Subtle warm white
 val MinimalOnSurfaceLight = Color(0xFF1a1a1a) // Deep text
 
 // Dark theme colors - sophisticated and deep
-val MinimalPrimaryDark = Color(0xFF818cf8)    // Lighter indigo for dark
+val MinimalPrimaryDark = Color(0xFF2196F3)    // Blue for dark theme
 val MinimalSurfaceDark = Color(0xFF0f0f0f)    // Deep black
 val MinimalBackgroundDark = Color(0xFF080808) // Ultra deep black
 val MinimalOnSurfaceDark = Color(0xFFfafafa)  // Pure white text
@@ -111,7 +111,7 @@ val PrimerGray200 = MinimalNeutral200
 val PrimerGray100 = MinimalNeutral100
 val PrimerGray50 = MinimalNeutral50
 
-val PrimerBlueDark = Color(0xFF818cf8)
+val PrimerBlueDark = Color(0xFFFFB74D)
 val PrimerGray900Dark = MinimalNeutral50
 val PrimerGray800Dark = MinimalNeutral100
 val PrimerGray700Dark = MinimalNeutral300

--- a/app/src/main/java/com/talauncher/ui/theme/Theme.kt
+++ b/app/src/main/java/com/talauncher/ui/theme/Theme.kt
@@ -410,12 +410,12 @@ private fun createCustomPaletteDefinition(
 ): PaletteDefinition {
     // Priority: direct color values > named option > fallback
     val primary = when {
-        customPrimaryColor != null -> parseHexColor(customPrimaryColor) ?: Color(0xFF6366F1)
+        customPrimaryColor != null -> parseHexColor(customPrimaryColor) ?: Color(0xFF2196F3)
         customColorOption != null -> {
             ColorPalettes.CustomColorOptions[customColorOption]?.get("primary")
                 ?: ColorPalettes.CustomColorOptions["Purple"]!!["primary"]!!
         }
-        else -> Color(0xFF6366F1) // Default purple
+        else -> Color(0xFF2196F3) // Default blue
     }
 
     val secondary = when {

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,9 +5,9 @@
     <color name="white">#FFFFFFFF</color>
 
     <!-- Default palette colors -->
-    <color name="default_primary_light">#FF6366F1</color>
-    <color name="default_primary_dark">#FF818CF8</color>
-    <color name="default_secondary">#FF06B6D4</color>
+    <color name="default_primary_light">#FF2196F3</color>
+    <color name="default_primary_dark">#FF2196F3</color>
+    <color name="default_secondary">#FFFF9800</color>
     <color name="default_tertiary_light">#FF4B5563</color>
     <color name="default_tertiary_dark">#FF9CA3AF</color>
     <color name="default_background_light">#FFFAFAFA</color>


### PR DESCRIPTION
## Summary
- switch the default theme palette to a blue primary (2196F3) and orange secondary (FF9800)
- refresh the settings color preview and custom color defaults to showcase the new palette
- align custom palette fallbacks and resources with the updated default colors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4afee9b88321b0069af1e7c37c26