### PR TITLE
Remove tinted overlays from preset dark backgrounds

### DIFF
--- a/app/src/main/java/com/talauncher/ui/components/ModernComponents.kt
+++ b/app/src/main/java/com/talauncher/ui/components/ModernComponents.kt
@@ -537,8 +537,8 @@ fun ModernBackdrop(
     }
 
     val backgroundColorValue = when (backgroundColor) {
-        "black" -> MaterialTheme.colorScheme.surface.copy(alpha = 0.1f)
-        "white" -> MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)
+        "black" -> Color.Black
+        "white" -> Color.White
         "system" -> MaterialTheme.colorScheme.background
         else -> runCatching { Color(android.graphics.Color.parseColor(backgroundColor)) }
             .getOrElse { MaterialTheme.colorScheme.background }


### PR DESCRIPTION
## Summary
- remove the surface-based tint that was applied to preset black and white backgrounds in ModernBackdrop
- ensure preset selections now use pure black and white values just like custom hex colors

## Testing
- ./gradlew :app:lint *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4d6684388321b34feb8935ab5287