### PR TITLE
Fix uninstall event refresh and rename dialog

### DIFF
--- a/app/src/main/java/com/talauncher/receivers/PackageChangeReceiver.kt
+++ b/app/src/main/java/com/talauncher/receivers/PackageChangeReceiver.kt
@@ -1,0 +1,98 @@
+package com.talauncher.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+class PackageChangeReceiver(
+    private val onPackageChanged: () -> Unit
+) : BroadcastReceiver() {
+
+    companion object {
+        private const val TAG = "PackageChangeReceiver"
+
+        fun register(
+            context: Context,
+            onPackageChanged: () -> Unit
+        ): PackageChangeReceiver {
+            val receiver = PackageChangeReceiver(onPackageChanged)
+            val intentFilter = IntentFilter().apply {
+                addAction(Intent.ACTION_PACKAGE_ADDED)
+                addAction(Intent.ACTION_PACKAGE_REMOVED)
+                addAction(Intent.ACTION_PACKAGE_REPLACED)
+                addDataScheme("package")
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.registerReceiver(
+                    receiver,
+                    intentFilter,
+                    Context.RECEIVER_NOT_EXPORTED
+                )
+            } else {
+                context.registerReceiver(receiver, intentFilter)
+            }
+
+            Log.d(TAG, "PackageChangeReceiver registered")
+            return receiver
+        }
+
+        fun unregister(context: Context, receiver: PackageChangeReceiver?) {
+            receiver?.let {
+                try {
+                    context.unregisterReceiver(it)
+                    Log.d(TAG, "PackageChangeReceiver unregistered")
+                } catch (e: IllegalArgumentException) {
+                    Log.w(TAG, "Attempted to unregister receiver that was not registered", e)
+                }
+            }
+        }
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (context == null || intent == null) {
+            Log.w(TAG, "Received null context or intent")
+            return
+        }
+
+        val action = intent.action
+        val packageName = intent.data?.schemeSpecificPart
+
+        when (action) {
+            Intent.ACTION_PACKAGE_ADDED -> {
+                Log.d(TAG, "Package added: $packageName")
+                triggerRefresh()
+            }
+            Intent.ACTION_PACKAGE_REMOVED -> {
+                Log.d(TAG, "Package removed: $packageName")
+                triggerRefresh()
+            }
+            Intent.ACTION_PACKAGE_REPLACED -> {
+                Log.d(TAG, "Package replaced: $packageName")
+                triggerRefresh()
+            }
+            else -> {
+                Log.d(TAG, "Received unexpected action: $action")
+            }
+        }
+    }
+
+    private fun triggerRefresh() {
+        scope.launch(Dispatchers.IO) {
+            try {
+                onPackageChanged()
+            } catch (e: Exception) {
+                Log.e(TAG, "Error during package change callback", e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/talauncher/ui/components/BaseDialog.kt
+++ b/app/src/main/java/com/talauncher/ui/components/BaseDialog.kt
@@ -1,0 +1,82 @@
+package com.talauncher.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.talauncher.ui.theme.PrimerShapes
+
+@Composable
+fun BaseDialog(
+    title: String,
+    onDismissRequest: () -> Unit,
+    confirmButton: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    dismissButton: (@Composable () -> Unit)? = null,
+    testTag: String? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier.then(
+            if (testTag != null) Modifier.testTag(testTag) else Modifier
+        ),
+        title = {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                content()
+            }
+        },
+        confirmButton = confirmButton,
+        dismissButton = dismissButton,
+        containerColor = MaterialTheme.colorScheme.surface,
+        shape = PrimerShapes.medium
+    )
+}
+
+@Composable
+fun BaseActionDialog(
+    title: String,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    dismissButton: (@Composable () -> Unit)? = null,
+    testTag: String? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier.then(
+            if (testTag != null) Modifier.testTag(testTag) else Modifier
+        ),
+        title = {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium
+            )
+        },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                content()
+            }
+        },
+        confirmButton = {},
+        dismissButton = dismissButton,
+        containerColor = MaterialTheme.colorScheme.surface,
+        shape = PrimerShapes.medium
+    )
+}

--- a/app/src/main/java/com/talauncher/ui/home/HomeDialogs.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeDialogs.kt
@@ -1,158 +1,22 @@
 package com.talauncher.ui.home
 
-import android.content.Context
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.BorderStroke
-import com.talauncher.R
+import androidx.compose.runtime.Composable
 import com.talauncher.data.model.AppInfo
 import com.talauncher.domain.quotes.QuotesProvider
-import com.talauncher.ui.components.ActionButton
-import com.talauncher.ui.theme.PrimerButton
-import com.talauncher.ui.theme.PrimerSecondaryButton
-import com.talauncher.ui.theme.PrimerShapes
-import com.talauncher.ui.theme.PrimerSpacing
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+
 @Composable
 fun FrictionDialog(
     appPackageName: String,
     onDismiss: () -> Unit,
     onProceed: (String) -> Unit,
     quotesProvider: QuotesProvider? = null
-) {
-    var reason by remember { mutableStateOf("") }
-    val context = LocalContext.current
+) = com.talauncher.ui.home.dialogs.FrictionDialog(
+    appPackageName = appPackageName,
+    onDismiss = onDismiss,
+    onProceed = onProceed,
+    quotesProvider = quotesProvider
+)
 
-    // Use provided quotes provider or create default one
-    val effectiveQuotesProvider = remember(context, quotesProvider) {
-        quotesProvider ?: MotivationalQuotesProvider(context)
-    }
-
-    val motivationalQuote = remember(appPackageName, effectiveQuotesProvider) {
-        effectiveQuotesProvider.getRandomQuote()
-    }
-
-    // Get app name for display
-    var appName by remember(appPackageName) { mutableStateOf(appPackageName) }
-
-    LaunchedEffect(appPackageName) {
-        appName = withContext(Dispatchers.IO) {
-            getAppDisplayName(context, appPackageName)
-        }
-    }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        modifier = Modifier.testTag("friction_dialog"),
-        title = {
-            Text(
-                text = stringResource(R.string.friction_dialog_title),
-                style = MaterialTheme.typography.headlineSmall,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-        },
-        text = {
-            FrictionDialogContent(
-                appName = appName,
-                reason = reason,
-                onReasonChange = { reason = it },
-                motivationalQuote = motivationalQuote
-            )
-        },
-        confirmButton = {
-            PrimerButton(
-                onClick = {
-                    if (reason.trim().isNotEmpty()) {
-                        onProceed(reason.trim())
-                    }
-                },
-                enabled = reason.trim().isNotEmpty(),
-                modifier = Modifier.testTag("friction_continue_button")
-            ) {
-                Text(stringResource(R.string.friction_dialog_continue))
-            }
-        },
-        dismissButton = {
-            PrimerSecondaryButton(
-                onClick = onDismiss,
-                modifier = Modifier.testTag("friction_cancel_button")
-            ) {
-                Text(stringResource(R.string.friction_dialog_cancel))
-            }
-        },
-        containerColor = MaterialTheme.colorScheme.surface,
-        shape = PrimerShapes.medium
-    )
-}
-
-@Composable
-private fun FrictionDialogContent(
-    appName: String,
-    reason: String,
-    onReasonChange: (String) -> Unit,
-    motivationalQuote: String
-) {
-    Column(
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Text(
-            text = stringResource(R.string.friction_dialog_marked_distracting, appName),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Text(
-            text = stringResource(R.string.friction_dialog_why),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = FontWeight.Medium
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        OutlinedTextField(
-            value = reason,
-            onValueChange = onReasonChange,
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag("friction_reason_input"),
-            placeholder = { Text(stringResource(R.string.friction_dialog_reason_placeholder)) },
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            shape = PrimerShapes.small,
-            colors = OutlinedTextFieldDefaults.colors(
-                focusedBorderColor = MaterialTheme.colorScheme.primary,
-                unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
-                cursorColor = MaterialTheme.colorScheme.primary
-            )
-        )
-
-        if (motivationalQuote.isNotBlank()) {
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = motivationalQuote,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth()
-            )
-        }
-    }
-}
 @Composable
 fun AppActionDialog(
     app: AppInfo?,
@@ -163,170 +27,37 @@ fun AppActionDialog(
     onUnhide: (String) -> Unit,
     onAppInfo: (String) -> Unit,
     onUninstall: (String) -> Unit
-) {
-    if (app == null) return
-
-    val isHidden = app.isHidden
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        modifier = Modifier.testTag("app_action_dialog"),
-        title = {
-            Text(
-                text = app.appName,
-                style = MaterialTheme.typography.titleMedium
-            )
-        },
-        text = {
-            AppActionDialogContent(
-                app = app,
-                isHidden = isHidden,
-                canUninstall = canUninstall,
-                onRename = onRename,
-                onHide = onHide,
-                onUnhide = onUnhide,
-                onAppInfo = onAppInfo,
-                onUninstall = onUninstall,
-                onDismiss = onDismiss
-            )
-        },
-        confirmButton = {},
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.app_action_dialog_cancel))
-            }
-        },
-        containerColor = MaterialTheme.colorScheme.surface,
-        shape = PrimerShapes.medium
-    )
-}
+) = com.talauncher.ui.home.dialogs.AppActionDialog(
+    app = app,
+    canUninstall = canUninstall,
+    onDismiss = onDismiss,
+    onRename = onRename,
+    onHide = onHide,
+    onUnhide = onUnhide,
+    onAppInfo = onAppInfo,
+    onUninstall = onUninstall
+)
 
 @Composable
-private fun AppActionDialogContent(
-    app: AppInfo,
-    isHidden: Boolean,
-    canUninstall: Boolean,
-    onRename: (AppInfo) -> Unit,
-    onHide: (String) -> Unit,
-    onUnhide: (String) -> Unit,
-    onAppInfo: (String) -> Unit,
-    onUninstall: (String) -> Unit,
+fun RenameAppDialog(
+    app: AppInfo?,
+    newName: String,
+    onNameChange: (String) -> Unit,
+    onConfirm: () -> Unit,
     onDismiss: () -> Unit
-) {
-    Column(
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Text(
-            text = stringResource(R.string.app_action_dialog_choose),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(PrimerSpacing.sm)
-        ) {
-            ActionButton(
-                label = stringResource(R.string.rename_app_action_label),
-                description = stringResource(R.string.rename_app_action_description),
-                modifier = Modifier.fillMaxWidth(),
-                onClick = {
-                    onRename(app)
-                    onDismiss()
-                }
-            )
-
-            if (isHidden) {
-                ActionButton(
-                    label = stringResource(R.string.app_action_unhide_label),
-                    description = stringResource(R.string.app_action_unhide_description),
-                    modifier = Modifier.fillMaxWidth(),
-                    onClick = {
-                        onUnhide(app.packageName)
-                        onDismiss()
-                    }
-                )
-            } else {
-                ActionButton(
-                    label = stringResource(R.string.app_action_hide_label),
-                    description = stringResource(R.string.app_action_hide_description),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag("hide_app_button"),
-                    onClick = {
-                        onHide(app.packageName)
-                        onDismiss()
-                    }
-                )
-            }
-
-            ActionButton(
-                label = stringResource(R.string.app_action_info_label),
-                description = stringResource(R.string.app_action_info_description),
-                modifier = Modifier.fillMaxWidth(),
-                onClick = {
-                    onAppInfo(app.packageName)
-                    onDismiss()
-                }
-            )
-
-            if (canUninstall) {
-                ActionButton(
-                    label = stringResource(R.string.app_action_uninstall_label),
-                    description = stringResource(R.string.app_action_uninstall_description),
-                    modifier = Modifier.fillMaxWidth(),
-                    onClick = {
-                        onUninstall(app.packageName)
-                        onDismiss()
-                    }
-                )
-            }
-        }
-    }
-}
+) = com.talauncher.ui.home.dialogs.RenameAppDialog(
+    app = app,
+    newName = newName,
+    onNameChange = onNameChange,
+    onConfirm = onConfirm,
+    onDismiss = onDismiss
+)
 
 @Composable
 fun ContactsPermissionDialog(
     onDismiss: () -> Unit,
     onConfirm: () -> Unit
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = {
-            Text(
-                text = stringResource(R.string.contact_permission_required_title),
-                style = MaterialTheme.typography.headlineSmall,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-        },
-        text = {
-            Text(
-                text = stringResource(R.string.contact_permission_required_message),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(stringResource(R.string.contact_permission_required_confirm))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.contact_permission_required_dismiss))
-            }
-        }
-    )
-}
-
-private suspend fun getAppDisplayName(context: Context, packageName: String): String {
-    return try {
-        val packageManager = context.packageManager
-        val appInfo = packageManager.getApplicationInfo(packageName, 0)
-        packageManager.getApplicationLabel(appInfo).toString()
-    } catch (e: Exception) {
-        packageName
-    }
-}
+) = com.talauncher.ui.home.dialogs.ContactsPermissionDialog(
+    onDismiss = onDismiss,
+    onConfirm = onConfirm
+)

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -459,6 +459,15 @@ fun HomeScreen(
             )
         }
 
+        // Rename App Dialog
+        RenameAppDialog(
+            app = uiState.appBeingRenamed,
+            newName = uiState.renameInput,
+            onNameChange = { viewModel.updateRenameInput(it) },
+            onConfirm = { viewModel.confirmRename() },
+            onDismiss = { viewModel.dismissRenameDialog() }
+        )
+
         // Friction barrier dialog for distracting apps
         if (uiState.showFrictionDialog) {
             run {

--- a/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
@@ -753,8 +753,40 @@ class HomeViewModel(
     }
 
     fun renameApp(app: AppInfo) {
-        // For now, just dismiss the dialog - renaming would require additional UI
         dismissAppActionDialog()
+        _uiState.value = _uiState.value.copy(
+            appBeingRenamed = app,
+            renameInput = app.appName
+        )
+    }
+
+    fun updateRenameInput(value: String) {
+        _uiState.value = _uiState.value.copy(renameInput = value)
+    }
+
+    fun dismissRenameDialog() {
+        _uiState.value = _uiState.value.copy(
+            appBeingRenamed = null,
+            renameInput = ""
+        )
+    }
+
+    fun confirmRename() {
+        val app = _uiState.value.appBeingRenamed ?: return
+        val newName = _uiState.value.renameInput.trim()
+        if (newName.isEmpty()) {
+            return
+        }
+
+        if (newName == app.appName) {
+            dismissRenameDialog()
+            return
+        }
+
+        viewModelScope.launch {
+            appRepository.renameApp(app.packageName, newName)
+            dismissRenameDialog()
+        }
     }
 
     fun hideApp(packageName: String) {
@@ -883,5 +915,7 @@ data class HomeUiState(
     val showAppActionDialog: Boolean = false,
     val selectedAppForAction: AppInfo? = null,
     val selectedAppSupportsUninstall: Boolean = false,
-    val isOtherAppsExpanded: Boolean = false
+    val isOtherAppsExpanded: Boolean = false,
+    val appBeingRenamed: AppInfo? = null,
+    val renameInput: String = ""
 )

--- a/app/src/main/java/com/talauncher/ui/home/dialogs/AppActionDialog.kt
+++ b/app/src/main/java/com/talauncher/ui/home/dialogs/AppActionDialog.kt
@@ -1,0 +1,145 @@
+package com.talauncher.ui.home.dialogs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.talauncher.R
+import com.talauncher.data.model.AppInfo
+import com.talauncher.ui.components.ActionButton
+import com.talauncher.ui.components.BaseActionDialog
+import com.talauncher.ui.theme.PrimerSpacing
+
+data class AppActionHandlers(
+    val onRename: (AppInfo) -> Unit,
+    val onHide: (String) -> Unit,
+    val onUnhide: (String) -> Unit,
+    val onAppInfo: (String) -> Unit,
+    val onUninstall: (String) -> Unit
+)
+
+@Composable
+fun AppActionDialog(
+    app: AppInfo?,
+    canUninstall: Boolean,
+    onDismiss: () -> Unit,
+    handlers: AppActionHandlers
+) {
+    if (app == null) return
+
+    AppActionDialog(
+        app = app,
+        canUninstall = canUninstall,
+        onDismiss = onDismiss,
+        onRename = handlers.onRename,
+        onHide = handlers.onHide,
+        onUnhide = handlers.onUnhide,
+        onAppInfo = handlers.onAppInfo,
+        onUninstall = handlers.onUninstall
+    )
+}
+
+@Composable
+fun AppActionDialog(
+    app: AppInfo?,
+    canUninstall: Boolean,
+    onDismiss: () -> Unit,
+    onRename: (AppInfo) -> Unit,
+    onHide: (String) -> Unit,
+    onUnhide: (String) -> Unit,
+    onAppInfo: (String) -> Unit,
+    onUninstall: (String) -> Unit
+) {
+    if (app == null) return
+
+    val isHidden = app.isHidden
+
+    BaseActionDialog(
+        title = app.appName,
+        onDismissRequest = onDismiss,
+        testTag = "app_action_dialog",
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.app_action_dialog_cancel))
+            }
+        }
+    ) {
+        Text(
+            text = stringResource(R.string.app_action_dialog_choose),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(PrimerSpacing.sm)
+        ) {
+            ActionButton(
+                label = stringResource(R.string.rename_app_action_label),
+                description = stringResource(R.string.rename_app_action_description),
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    onRename(app)
+                    onDismiss()
+                }
+            )
+
+            if (isHidden) {
+                ActionButton(
+                    label = stringResource(R.string.app_action_unhide_label),
+                    description = stringResource(R.string.app_action_unhide_description),
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        onUnhide(app.packageName)
+                        onDismiss()
+                    }
+                )
+            } else {
+                ActionButton(
+                    label = stringResource(R.string.app_action_hide_label),
+                    description = stringResource(R.string.app_action_hide_description),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("hide_app_button"),
+                    onClick = {
+                        onHide(app.packageName)
+                        onDismiss()
+                    }
+                )
+            }
+
+            ActionButton(
+                label = stringResource(R.string.app_action_info_label),
+                description = stringResource(R.string.app_action_info_description),
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    onAppInfo(app.packageName)
+                    onDismiss()
+                }
+            )
+
+            if (canUninstall) {
+                ActionButton(
+                    label = stringResource(R.string.app_action_uninstall_label),
+                    description = stringResource(R.string.app_action_uninstall_description),
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        onUninstall(app.packageName)
+                        onDismiss()
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/talauncher/ui/home/dialogs/ContactsPermissionDialog.kt
+++ b/app/src/main/java/com/talauncher/ui/home/dialogs/ContactsPermissionDialog.kt
@@ -1,0 +1,37 @@
+package com.talauncher.ui.home.dialogs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.talauncher.R
+import com.talauncher.ui.components.BaseDialog
+
+@Composable
+fun ContactsPermissionDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    BaseDialog(
+        title = stringResource(R.string.contact_permission_required_title),
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.contact_permission_required_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.contact_permission_required_dismiss))
+            }
+        }
+    ) {
+        Text(
+            text = stringResource(R.string.contact_permission_required_message),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/app/src/main/java/com/talauncher/ui/home/dialogs/FrictionDialog.kt
+++ b/app/src/main/java/com/talauncher/ui/home/dialogs/FrictionDialog.kt
@@ -1,0 +1,153 @@
+package com.talauncher.ui.home.dialogs
+
+import android.content.Context
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.KeyboardOptions
+import com.talauncher.R
+import com.talauncher.domain.quotes.QuotesProvider
+import com.talauncher.ui.components.BaseDialog
+import com.talauncher.ui.home.MotivationalQuotesProvider
+import com.talauncher.ui.theme.PrimerButton
+import com.talauncher.ui.theme.PrimerSecondaryButton
+import com.talauncher.ui.theme.PrimerShapes
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+interface AppNameProvider {
+    suspend fun getAppDisplayName(packageName: String): String
+}
+
+class DefaultAppNameProvider(private val context: Context) : AppNameProvider {
+    override suspend fun getAppDisplayName(packageName: String): String {
+        return try {
+            val packageManager = context.packageManager
+            val appInfo = packageManager.getApplicationInfo(packageName, 0)
+            packageManager.getApplicationLabel(appInfo).toString()
+        } catch (e: Exception) {
+            packageName
+        }
+    }
+}
+
+@Composable
+fun FrictionDialog(
+    appPackageName: String,
+    onDismiss: () -> Unit,
+    onProceed: (String) -> Unit,
+    quotesProvider: QuotesProvider? = null,
+    appNameProvider: AppNameProvider? = null
+) {
+    var reason by remember { mutableStateOf("") }
+    val context = LocalContext.current
+
+    val effectiveQuotesProvider = remember(context, quotesProvider) {
+        quotesProvider ?: MotivationalQuotesProvider(context)
+    }
+
+    val effectiveAppNameProvider = remember(context, appNameProvider) {
+        appNameProvider ?: DefaultAppNameProvider(context)
+    }
+
+    val motivationalQuote = remember(appPackageName, effectiveQuotesProvider) {
+        effectiveQuotesProvider.getRandomQuote()
+    }
+
+    var appName by remember(appPackageName) { mutableStateOf(appPackageName) }
+
+    LaunchedEffect(appPackageName) {
+        appName = withContext(Dispatchers.IO) {
+            effectiveAppNameProvider.getAppDisplayName(appPackageName)
+        }
+    }
+
+    BaseDialog(
+        title = stringResource(R.string.friction_dialog_title),
+        onDismissRequest = onDismiss,
+        testTag = "friction_dialog",
+        confirmButton = {
+            PrimerButton(
+                onClick = {
+                    if (reason.trim().isNotEmpty()) {
+                        onProceed(reason.trim())
+                    }
+                },
+                enabled = reason.trim().isNotEmpty(),
+                modifier = Modifier.testTag("friction_continue_button")
+            ) {
+                Text(stringResource(R.string.friction_dialog_continue))
+            }
+        },
+        dismissButton = {
+            PrimerSecondaryButton(
+                onClick = onDismiss,
+                modifier = Modifier.testTag("friction_cancel_button")
+            ) {
+                Text(stringResource(R.string.friction_dialog_cancel))
+            }
+        }
+    ) {
+        Text(
+            text = stringResource(R.string.friction_dialog_marked_distracting, appName),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = stringResource(R.string.friction_dialog_why),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Medium
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = reason,
+            onValueChange = { reason = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("friction_reason_input"),
+            placeholder = { Text(stringResource(R.string.friction_dialog_reason_placeholder)) },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            shape = PrimerShapes.small,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
+                cursorColor = MaterialTheme.colorScheme.primary
+            )
+        )
+
+        if (motivationalQuote.isNotBlank()) {
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = motivationalQuote,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/talauncher/ui/home/dialogs/RenameAppDialog.kt
+++ b/app/src/main/java/com/talauncher/ui/home/dialogs/RenameAppDialog.kt
@@ -1,0 +1,116 @@
+package com.talauncher.ui.home.dialogs
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.talauncher.R
+import com.talauncher.data.model.AppInfo
+import com.talauncher.ui.components.BaseDialog
+import com.talauncher.ui.theme.PrimerButton
+import com.talauncher.ui.theme.PrimerSecondaryButton
+import com.talauncher.ui.theme.PrimerShapes
+
+interface RenameDialogState {
+    val newName: String
+    fun onNameChange(value: String)
+}
+
+data class DefaultRenameDialogState(
+    override val newName: String,
+    private val onValueChange: (String) -> Unit
+) : RenameDialogState {
+    override fun onNameChange(value: String) {
+        onValueChange(value)
+    }
+}
+
+@Composable
+fun RenameAppDialog(
+    app: AppInfo?,
+    state: RenameDialogState,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    if (app == null) return
+
+    BaseDialog(
+        title = stringResource(R.string.rename_app_dialog_title, app.appName),
+        onDismissRequest = onDismiss,
+        testTag = "rename_app_dialog",
+        confirmButton = {
+            PrimerButton(
+                onClick = onConfirm,
+                enabled = state.newName.trim().isNotEmpty(),
+                modifier = Modifier.testTag("rename_confirm_button")
+            ) {
+                Text(stringResource(R.string.rename_app_dialog_confirm))
+            }
+        },
+        dismissButton = {
+            PrimerSecondaryButton(
+                onClick = onDismiss,
+                modifier = Modifier.testTag("rename_cancel_button")
+            ) {
+                Text(stringResource(R.string.app_action_dialog_cancel))
+            }
+        }
+    ) {
+        Text(
+            text = stringResource(R.string.rename_app_dialog_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = state.newName,
+            onValueChange = state::onNameChange,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("rename_input_field"),
+            label = { Text(stringResource(R.string.rename_app_dialog_field_label)) },
+            placeholder = { Text(stringResource(R.string.rename_app_dialog_placeholder)) },
+            supportingText = { Text(stringResource(R.string.rename_app_dialog_supporting_text)) },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(
+                onDone = { if (state.newName.trim().isNotEmpty()) onConfirm() }
+            ),
+            singleLine = true,
+            shape = PrimerShapes.small,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
+                cursorColor = MaterialTheme.colorScheme.primary
+            )
+        )
+    }
+}
+
+@Composable
+fun RenameAppDialog(
+    app: AppInfo?,
+    newName: String,
+    onNameChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    RenameAppDialog(
+        app = app,
+        state = DefaultRenameDialogState(newName, onNameChange),
+        onConfirm = onConfirm,
+        onDismiss = onDismiss
+    )
+}


### PR DESCRIPTION
## Summary
- Fixed uninstall event not triggering app list refresh
- Fixed rename functionality not opening dialog
- Refactored all dialogs to follow SOLID principles with dependency injection

## Changes

### 🐛 Bug Fixes
- **PackageChangeReceiver**: Added broadcast receiver to listen for app install/uninstall/update events
- **Auto-refresh**: App list now automatically updates when packages change
- **Rename Dialog**: Restored complete rename dialog implementation that was lost during AppDrawerScreen refactoring
- **Backup Refresh**: Added app sync in MainActivity.onResume() as fallback

### ♻️ Refactoring
- **Generic Dialog Components**: Created BaseDialog and BaseActionDialog for reusability
- **Separation of Concerns**: Each dialog now in separate file under `ui/home/dialogs/`
- **Dependency Injection**: Dialog state management and providers use DI for testability
- **SOLID Principles**: All dialogs follow Single Responsibility, Open/Closed, and Dependency Inversion principles
- **Minimal Comments**: Self-documenting code with clear naming

## Files Changed
- `MainActivity.kt`: Register/unregister PackageChangeReceiver, add onResume refresh
- `PackageChangeReceiver.kt`: New broadcast receiver for package events
- `BaseDialog.kt`: Generic dialog components
- `HomeViewModel.kt`: Complete rename dialog state management
- `HomeDialogs.kt`: Simplified to re-export individual dialogs
- `HomeScreen.kt`: Add RenameAppDialog invocation
- `dialogs/AppActionDialog.kt`: Extracted with AppActionHandlers
- `dialogs/RenameAppDialog.kt`: Extracted with RenameDialogState interface
- `dialogs/FrictionDialog.kt`: Extracted with AppNameProvider interface
- `dialogs/ContactsPermissionDialog.kt`: Extracted simple permission dialog

## Test Plan
- [ ] Install an app and verify launcher app list updates automatically
- [ ] Uninstall an app and verify it's removed from launcher without manual refresh
- [ ] Long-press an app → Rename → verify dialog opens
- [ ] Enter new name and confirm → verify app is renamed
- [ ] Test all other dialogs still work (app actions, friction, permissions)
- [ ] Verify no crashes or memory leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)