### PR TITLE
Add distracting app toggle to app action dialog

### DIFF
--- a/app/src/main/java/com/talauncher/ui/home/HomeDialogs.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeDialogs.kt
@@ -25,6 +25,8 @@ fun AppActionDialog(
     onRename: (AppInfo) -> Unit,
     onHide: (String) -> Unit,
     onUnhide: (String) -> Unit,
+    onMarkDistracting: (String) -> Unit,
+    onUnmarkDistracting: (String) -> Unit,
     onAppInfo: (String) -> Unit,
     onUninstall: (String) -> Unit
 ) = com.talauncher.ui.home.dialogs.AppActionDialog(
@@ -34,6 +36,8 @@ fun AppActionDialog(
     onRename = onRename,
     onHide = onHide,
     onUnhide = onUnhide,
+    onMarkDistracting = onMarkDistracting,
+    onUnmarkDistracting = onUnmarkDistracting,
     onAppInfo = onAppInfo,
     onUninstall = onUninstall
 )

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -444,6 +444,8 @@ fun HomeScreen(
                 onRename = { app -> viewModel.renameApp(app) },
                 onHide = { packageName -> viewModel.hideApp(packageName) },
                 onUnhide = { packageName -> viewModel.unhideApp(packageName) },
+                onMarkDistracting = { packageName -> viewModel.markAppAsDistracting(packageName) },
+                onUnmarkDistracting = { packageName -> viewModel.unmarkAppAsDistracting(packageName) },
                 onAppInfo = { packageName -> viewModel.openAppInfo(packageName) },
                 onUninstall = { packageName -> viewModel.uninstallApp(packageName) }
             )

--- a/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
@@ -906,6 +906,36 @@ class HomeViewModel(
         }
     }
 
+    fun markAppAsDistracting(packageName: String) {
+        viewModelScope.launch {
+            try {
+                appRepository.updateDistractingStatus(packageName, true)
+                dismissAppActionDialog()
+            } catch (e: Exception) {
+                errorHandler?.showError(
+                    "Failed to mark app as distracting",
+                    e.message ?: "Unknown error",
+                    e
+                )
+            }
+        }
+    }
+
+    fun unmarkAppAsDistracting(packageName: String) {
+        viewModelScope.launch {
+            try {
+                appRepository.updateDistractingStatus(packageName, false)
+                dismissAppActionDialog()
+            } catch (e: Exception) {
+                errorHandler?.showError(
+                    "Failed to remove distracting status",
+                    e.message ?: "Unknown error",
+                    e
+                )
+            }
+        }
+    }
+
     fun openAppInfo(packageName: String) {
         try {
             val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {

--- a/app/src/main/java/com/talauncher/ui/home/dialogs/AppActionDialog.kt
+++ b/app/src/main/java/com/talauncher/ui/home/dialogs/AppActionDialog.kt
@@ -23,6 +23,8 @@ data class AppActionHandlers(
     val onRename: (AppInfo) -> Unit,
     val onHide: (String) -> Unit,
     val onUnhide: (String) -> Unit,
+    val onMarkDistracting: (String) -> Unit,
+    val onUnmarkDistracting: (String) -> Unit,
     val onAppInfo: (String) -> Unit,
     val onUninstall: (String) -> Unit
 )
@@ -43,6 +45,8 @@ fun AppActionDialog(
         onRename = handlers.onRename,
         onHide = handlers.onHide,
         onUnhide = handlers.onUnhide,
+        onMarkDistracting = handlers.onMarkDistracting,
+        onUnmarkDistracting = handlers.onUnmarkDistracting,
         onAppInfo = handlers.onAppInfo,
         onUninstall = handlers.onUninstall
     )
@@ -56,12 +60,15 @@ fun AppActionDialog(
     onRename: (AppInfo) -> Unit,
     onHide: (String) -> Unit,
     onUnhide: (String) -> Unit,
+    onMarkDistracting: (String) -> Unit,
+    onUnmarkDistracting: (String) -> Unit,
     onAppInfo: (String) -> Unit,
     onUninstall: (String) -> Unit
 ) {
     if (app == null) return
 
     val isHidden = app.isHidden
+    val isDistracting = app.isDistracting
 
     BaseActionDialog(
         title = app.appName,
@@ -94,6 +101,28 @@ fun AppActionDialog(
                     onDismiss()
                 }
             )
+
+            if (isDistracting) {
+                ActionButton(
+                    label = stringResource(R.string.app_action_unmark_distracting_label),
+                    description = stringResource(R.string.app_action_unmark_distracting_description),
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        onUnmarkDistracting(app.packageName)
+                        onDismiss()
+                    }
+                )
+            } else {
+                ActionButton(
+                    label = stringResource(R.string.app_action_mark_distracting_label),
+                    description = stringResource(R.string.app_action_mark_distracting_description),
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        onMarkDistracting(app.packageName)
+                        onDismiss()
+                    }
+                )
+            }
 
             if (isHidden) {
                 ActionButton(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,6 +209,10 @@
     <string name="app_action_unhide_description">Move this app back to the main list.</string>
     <string name="app_action_hide_label">Hide app</string>
     <string name="app_action_hide_description">Move this app to the hidden list.</string>
+    <string name="app_action_mark_distracting_label">Mark as distracting</string>
+    <string name="app_action_mark_distracting_description">Add friction before opening this app.</string>
+    <string name="app_action_unmark_distracting_label">Remove distracting label</string>
+    <string name="app_action_unmark_distracting_description">Stop showing friction for this app.</string>
     <string name="app_action_info_label">View app info</string>
     <string name="app_action_info_description">Open the system settings page for this app.</string>
     <string name="app_action_uninstall_label">Uninstall app</string>


### PR DESCRIPTION
## Summary
- add mark and unmark distracting options to the app action dialog
- connect the new actions to HomeViewModel so distracting status updates persist
- add user-facing copy for the new menu items

## Testing
- ./gradlew test *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd3a860d48321bceb741eef3e4528