### PR TITLE
Refine app icon style selection

### DIFF
--- a/app/src/main/java/com/talauncher/data/model/SettingsOptions.kt
+++ b/app/src/main/java/com/talauncher/data/model/SettingsOptions.kt
@@ -58,7 +58,7 @@ enum class ColorPaletteOption(val label: String) {
 
 enum class AppIconStyleOption(val label: String) {
     ORIGINAL("Original colors"),
-    BLACK_AND_WHITE("Black & white"),
+    BLACK_AND_WHITE("Monochrome"),
     HIDDEN("No icons");
 
     val storageValue: String

--- a/app/src/main/java/com/talauncher/ui/settings/UIThemeSettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/UIThemeSettingsScreen.kt
@@ -119,23 +119,20 @@ private fun AppIconStyleSection(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
 
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            AppIconStyleOption.entries.forEach { option ->
-                FilterChip(
-                    selected = appIconStyle == option,
-                    onClick = { onUpdateAppIconStyle(option) },
-                    label = {
-                        Text(
-                            text = option.label,
-                            maxLines = 1
-                        )
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
+        ChipGrid(
+            items = AppIconStyleOption.entries,
+            modifier = Modifier.fillMaxWidth()
+        ) { option ->
+            FilterChip(
+                selected = appIconStyle == option,
+                onClick = { onUpdateAppIconStyle(option) },
+                label = {
+                    Text(
+                        text = option.label,
+                        maxLines = 1
+                    )
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- rename the black and white app icon option to Monochrome for clarity
- reuse the generic ChipGrid component in the app icon style section for consistency with other settings

## Testing
- ./gradlew test *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de1fd801b08321895591fde9767bbf