### PR TITLE
Run only debug unit tests in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
     # CI requires a clean working tree due to checkGitStatus task
 
     - name: Run unit tests
-      run: ./gradlew test --no-daemon --stacktrace
+      run: ./gradlew :app:testDebugUnitTest --no-daemon --stacktrace
 
     - name: Build debug APK
       run: ./gradlew assembleDebug --no-daemon --stacktrace


### PR DESCRIPTION
## Summary
- update the CI workflow to execute only the debug unit test variant
- keep the Gradle invocation aligned with standard Android practice

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68de21ab87508321a63f9423deeb341c