### PR TITLE
Match pinned apps styling with recent apps

### DIFF
--- a/app/src/main/java/com/talauncher/ui/home/HomeListItems.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeListItems.kt
@@ -117,7 +117,8 @@ fun SearchResultItem(
 fun PinnedAppItem(
     appInfo: AppInfo,
     onClick: () -> Unit,
-    onLongClick: () -> Unit
+    onLongClick: () -> Unit,
+    iconStyle: AppIconStyleOption
 ) {
     PrimerCard(
         modifier = Modifier
@@ -127,9 +128,9 @@ fun PinnedAppItem(
                 onLongClick = onLongClick
             ),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.05f)
         ),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.2f))
     ) {
         Row(
             modifier = Modifier
@@ -138,12 +139,38 @@ fun PinnedAppItem(
                 .heightIn(min = PrimerListItemDefaults.minHeight),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            if (iconStyle != AppIconStyleOption.HIDDEN) {
+                AppIcon(
+                    packageName = appInfo.packageName,
+                    appName = appInfo.appName,
+                    iconStyle = iconStyle
+                )
+                Spacer(modifier = Modifier.width(PrimerSpacing.md))
+            }
+
             Text(
                 text = appInfo.appName,
+                modifier = Modifier.weight(1f),
                 style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.weight(1f)
+                color = MaterialTheme.colorScheme.onSurface
             )
+
+            // Pinned indicator badge
+            Surface(
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+                shape = PrimerShapes.small,
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.3f))
+            ) {
+                Text(
+                    text = stringResource(R.string.home_pinned_badge),
+                    modifier = Modifier.padding(
+                        horizontal = PrimerSpacing.xs,
+                        vertical = 2.dp
+                    ),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -317,15 +317,14 @@ fun HomeScreen(
                             }
 
                             items(uiState.pinnedApps, key = { "pinned_${it.packageName}" }) { app ->
-                                ModernAppItem(
-                                    appName = app.appName,
-                                    packageName = app.packageName,
+                                PinnedAppItem(
+                                    appInfo = app,
                                     onClick = { viewModel.launchApp(app.packageName) },
                                     onLongClick = {
                                         hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                         viewModel.showAppActionDialog(app)
                                     },
-                                    appIconStyle = uiState.appIconStyle
+                                    iconStyle = uiState.appIconStyle
                                 )
                             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,7 @@
     <string name="home_other_apps_summary_plural">%1$d apps hidden from the main list.</string>
     <string name="home_other_apps_hint">Tap to reveal these hidden apps.</string>
     <string name="home_recent_badge">Recent</string>
+    <string name="home_pinned_badge">Pinned</string>
 
     <!-- App Action Dialog -->
     <string name="app_action_dialog_choose">Choose an action:</string>


### PR DESCRIPTION
## Summary
- Updated `PinnedAppItem` composable to match the visual styling of `RecentAppItem`
- Added icon support to pinned apps (respects icon style setting)
- Added "Pinned" badge with primary color theme
- Switched from using `ModernAppItem` to dedicated `PinnedAppItem` in HomeScreen
- Added `home_pinned_badge` string resource

## Changes Made
1. **PinnedAppItem composable** (HomeListItems.kt):
   - Added `iconStyle` parameter for icon support
   - Changed background to `primary.copy(alpha = 0.05f)` (matching recent apps)
   - Changed border to `primary.copy(alpha = 0.2f)` (matching recent apps)
   - Added "Pinned" badge with same styling as "Recent" badge
   - Added app icon display with conditional rendering

2. **HomeScreen** (HomeScreen.kt):
   - Updated pinned apps section to use `PinnedAppItem` instead of `ModernAppItem`
   - Passed `iconStyle` parameter to maintain consistency with app icon settings

3. **String resources** (strings.xml):
   - Added `home_pinned_badge` string resource with value "Pinned"

## Visual Consistency
Both pinned and recent apps now share:
- Primary color tinted background (5% opacity)
- Primary color border (20% opacity)
- Badge indicator with primary color theme
- Icon support (respects icon style setting)
- Consistent padding and typography

## Testing
- ✅ Build passes successfully
- ✅ No compilation errors
- ✅ All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)