### PR TITLE
feature/onboarding revamp

### DIFF
--- a/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
@@ -1,9 +1,8 @@
-package com.talauncher.ui.onboarding
+﻿package com.talauncher.ui.onboarding
 
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
@@ -12,7 +11,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Info
@@ -256,7 +255,7 @@ private fun PermissionStep(
             Spacer(Modifier.height(12.dp))
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
                 if (onBack != null) {
-                    TextButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, contentDescription = null); Spacer(Modifier.width(8.dp)); Text(stringResource(R.string.back)) }
+                    TextButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null); Spacer(Modifier.width(8.dp)); Text(stringResource(R.string.back)) }
                 } else {
                     Spacer(Modifier.width(1.dp))
                 }
@@ -266,6 +265,49 @@ private fun PermissionStep(
                         Spacer(Modifier.width(8.dp))
                     }
                     Button(onClick = onNext, enabled = canProceed) { Text(stringResource(R.string.next)) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccordionSection(
+    title: String,
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    Column(Modifier.fillMaxWidth()) {
+        Surface(
+            onClick = onToggle,
+            shape = RoundedCornerShape(12.dp),
+            tonalElevation = 1.dp,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(title, style = MaterialTheme.typography.titleMedium, modifier = Modifier.weight(1f))
+                Icon(
+                    imageVector = if (isExpanded) Icons.Filled.Check else Icons.Filled.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+        if (isExpanded) {
+            Spacer(Modifier.height(8.dp))
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                tonalElevation = 0.dp,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(Modifier.padding(12.dp)) {
+                    content()
                 }
             }
         }
@@ -289,47 +331,77 @@ private fun AppearanceStep(
     onBack: () -> Unit,
     onSkip: () -> Unit
 ) {
+    enum class AppearanceSection { THEME_MODE, ICON_STYLE, THEME_OPTIONS, WALLPAPER }
+    var expandedSection by remember { mutableStateOf(AppearanceSection.THEME_MODE) }
+
     Column(Modifier.fillMaxWidth()) {
         Text(stringResource(R.string.onboarding_appearance_title), style = MaterialTheme.typography.titleLarge)
         Spacer(Modifier.height(12.dp))
 
-        // Theme
-        Text(stringResource(R.string.theme_mode_title), style = MaterialTheme.typography.titleMedium)
-        Spacer(Modifier.height(8.dp))
-        FlowRowChipsTheme(selectedTheme, onSelectTheme)
-
-        Spacer(Modifier.height(16.dp))
-
-        // App icon style
-        Text(stringResource(R.string.settings_app_icons), style = MaterialTheme.typography.titleMedium)
-        Text(
-            text = stringResource(R.string.settings_app_icons_subtitle),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Spacer(Modifier.height(8.dp))
-        FlowRowChipsIcon(selectedIconStyle, onSelectIconStyle)
-
-        Spacer(Modifier.height(16.dp))
-
-        // Wallpaper quick pick
-        Text(stringResource(R.string.wallpaper_settings_title), style = MaterialTheme.typography.titleMedium)
-        Spacer(Modifier.height(8.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(text = stringResource(R.string.settings_show_wallpaper_title), modifier = Modifier.weight(1f))
-            Switch(checked = showWallpaper, onCheckedChange = onToggleWallpaper)
+        AccordionSection(
+            title = stringResource(R.string.theme_mode_title),
+            isExpanded = expandedSection == AppearanceSection.THEME_MODE,
+            onToggle = { expandedSection = AppearanceSection.THEME_MODE }
+        ) {
+            FlowRowChipsTheme(selectedTheme, onSelectTheme)
         }
-        if (showWallpaper) {
+
+        Spacer(Modifier.height(12.dp))
+
+        AccordionSection(
+            title = stringResource(R.string.settings_app_icons),
+            isExpanded = expandedSection == AppearanceSection.ICON_STYLE,
+            onToggle = { expandedSection = AppearanceSection.ICON_STYLE }
+        ) {
+            Text(
+                text = stringResource(R.string.settings_app_icons_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
             Spacer(Modifier.height(8.dp))
-            OutlinedButton(onClick = onPickWallpaper, modifier = Modifier.fillMaxWidth()) {
-                Text(stringResource(R.string.custom_wallpaper_choose))
+            FlowRowChipsIcon(selectedIconStyle, onSelectIconStyle)
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        AccordionSection(
+            title = stringResource(R.string.color_palette_title),
+            isExpanded = expandedSection == AppearanceSection.THEME_OPTIONS,
+            onToggle = { expandedSection = AppearanceSection.THEME_OPTIONS }
+        ) {
+            val obVm: OnboardingViewModel = viewModel()
+            val obState by obVm.uiState.collectAsState()
+            com.talauncher.ui.components.ColorPaletteSelector(
+                selectedPalette = obState.selectedColorPalette,
+                onPaletteSelected = { obVm.setColorPalette(it) },
+                currentCustomColor = obState.customColorOption,
+                onCustomColorSelected = { colorName -> obVm.setCustomPalette(colorName) }
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        AccordionSection(
+            title = stringResource(R.string.wallpaper_settings_title),
+            isExpanded = expandedSection == AppearanceSection.WALLPAPER,
+            onToggle = { expandedSection = AppearanceSection.WALLPAPER }
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = stringResource(R.string.settings_show_wallpaper_title), modifier = Modifier.weight(1f))
+                Switch(checked = showWallpaper, onCheckedChange = onToggleWallpaper)
+            }
+            if (showWallpaper) {
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(onClick = onPickWallpaper, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.custom_wallpaper_choose))
+                }
             }
         }
 
-        Spacer(Modifier.height(24.dp))
+        Spacer(Modifier.height(16.dp))
         Text(stringResource(R.string.color_palette_preview_title), style = MaterialTheme.typography.titleMedium)
         Spacer(Modifier.height(8.dp))
-        // Preview with wallpaper backdrop (constrained size, maintained aspect ratio)
+
         com.talauncher.ui.components.ModernBackdrop(
             showWallpaper = showWallpaper,
             blurAmount = wallpaperBlurAmount,
@@ -337,20 +409,20 @@ private fun AppearanceStep(
             opacity = backgroundOpacity,
             customWallpaperPath = customWallpaperPath,
             modifier = Modifier
-                .fillMaxWidth(0.9f)
+                .fillMaxWidth(0.72f)
                 .aspectRatio(9f / 19.5f)
                 .clip(RoundedCornerShape(16.dp))
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(8.dp)) {
-                ModernAppItem(appName = "Calendar", packageName = "com.android.calendar", onClick = {}, appIconStyle = selectedIconStyle)
-                ModernAppItem(appName = "Messages", packageName = "com.android.messaging", onClick = {}, appIconStyle = selectedIconStyle)
-                ModernAppItem(appName = "Notes", packageName = "com.example.notes", onClick = {}, appIconStyle = selectedIconStyle)
+                ModernAppItem(appName = "Calendar", packageName = "com.android.calendar", onClick = {}, appIconStyle = selectedIconStyle, enableGlassmorphism = true)
+                ModernAppItem(appName = "Messages", packageName = "com.android.messaging", onClick = {}, appIconStyle = selectedIconStyle, enableGlassmorphism = true)
+                ModernAppItem(appName = "Notes", packageName = "com.example.notes", onClick = {}, appIconStyle = selectedIconStyle, enableGlassmorphism = true)
             }
         }
 
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(12.dp))
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            TextButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, contentDescription = null); Spacer(Modifier.width(8.dp)); Text(stringResource(R.string.back)) }
+            TextButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null); Spacer(Modifier.width(8.dp)); Text(stringResource(R.string.back)) }
             Row {
                 TextButton(onClick = onSkip) { Text(stringResource(R.string.skip_for_now)) }
                 Spacer(Modifier.width(8.dp))
@@ -359,7 +431,6 @@ private fun AppearanceStep(
         }
     }
 }
-
 @Composable
 private fun FlowRowChipsTheme(selected: ThemeModeOption, onSelect: (ThemeModeOption) -> Unit) {
     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -377,3 +448,5 @@ private fun FlowRowChipsIcon(selected: AppIconStyleOption, onSelect: (AppIconSty
         }
     }
 }
+
+

--- a/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
 import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.rememberScrollState
@@ -44,6 +45,10 @@ private enum class OnboardingStepId {
     LOCATION,
     APPEARANCE
 }
+
+private enum class AppearanceSection { THEME_MODE, ICON_STYLE, THEME_OPTIONS, WALLPAPER }
+
+
 
 @Composable
 fun OnboardingScreen(
@@ -280,17 +285,15 @@ private fun AccordionSection(
 ) {
     Column(Modifier.fillMaxWidth()) {
         Surface(
-            onClick = onToggle,
             shape = RoundedCornerShape(12.dp),
             tonalElevation = 1.dp,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+            Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp).clickable { onToggle() },
+                verticalAlignment = Alignment.CenterVertically) {
+
+
+
                 Text(title, style = MaterialTheme.typography.titleMedium, modifier = Modifier.weight(1f))
                 Icon(
                     imageVector = if (isExpanded) Icons.Filled.Check else Icons.Filled.Info,
@@ -331,8 +334,7 @@ private fun AppearanceStep(
     onBack: () -> Unit,
     onSkip: () -> Unit
 ) {
-    enum class AppearanceSection { THEME_MODE, ICON_STYLE, THEME_OPTIONS, WALLPAPER }
-    var expandedSection by remember { mutableStateOf(AppearanceSection.THEME_MODE) }
+    var expandedSection by remember { mutableStateOf<AppearanceSection>(AppearanceSection.THEME_MODE) }
 
     Column(Modifier.fillMaxWidth()) {
         Text(stringResource(R.string.onboarding_appearance_title), style = MaterialTheme.typography.titleLarge)
@@ -448,5 +450,13 @@ private fun FlowRowChipsIcon(selected: AppIconStyleOption, onSelect: (AppIconSty
         }
     }
 }
+
+
+
+
+
+
+
+
 
 

--- a/app/src/main/java/com/talauncher/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/onboarding/OnboardingViewModel.kt
@@ -1,8 +1,9 @@
-package com.talauncher.ui.onboarding
+﻿package com.talauncher.ui.onboarding
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.talauncher.data.model.AppIconStyleOption
+import com.talauncher.data.model.ColorPaletteOption
 import com.talauncher.data.model.ThemeModeOption
 import com.talauncher.data.repository.SettingsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,6 +37,34 @@ class OnboardingViewModel(
         viewModelScope.launch {
             settingsRepository.updateAppIconStyle(style)
             _uiState.value = _uiState.value.copy(selectedAppIconStyle = style)
+        }
+    }
+
+    fun setColorPalette(palette: ColorPaletteOption) {
+        viewModelScope.launch {
+            settingsRepository.updateColorPalette(palette)
+            _uiState.value = _uiState.value.copy(selectedColorPalette = palette)
+        }
+    }
+
+    fun setCustomPalette(
+        customColorOption: String?,
+        customPrimaryColor: String? = null,
+        customSecondaryColor: String? = null
+    ) {
+        viewModelScope.launch {
+            settingsRepository.setCustomPalette(
+                palette = ColorPaletteOption.CUSTOM,
+                customColorOption = customColorOption,
+                customPrimaryColor = customPrimaryColor,
+                customSecondaryColor = customSecondaryColor
+            )
+            _uiState.value = _uiState.value.copy(
+                selectedColorPalette = ColorPaletteOption.CUSTOM,
+                customColorOption = customColorOption,
+                customPrimaryColor = customPrimaryColor,
+                customSecondaryColor = customSecondaryColor
+            )
         }
     }
 
@@ -82,11 +111,16 @@ class OnboardingViewModel(
     }
 }
 
+
 data class OnboardingUiState(
     val currentStepIndex: Int = 0,
     val isOnboardingCompleted: Boolean = false,
     val selectedThemeMode: ThemeModeOption = ThemeModeOption.SYSTEM,
     val selectedAppIconStyle: AppIconStyleOption = AppIconStyleOption.ORIGINAL,
+    val selectedColorPalette: ColorPaletteOption = ColorPaletteOption.DEFAULT,
+    val customColorOption: String? = null,
+    val customPrimaryColor: String? = null,
+    val customSecondaryColor: String? = null,
     val showWallpaper: Boolean = true,
     val wallpaperBlurAmount: Float = 0f,
     val backgroundOpacity: Float = 1f,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+﻿<resources>
     <string name="app_name">TALauncher</string>
     <string name="focus_mode">Focus Mode</string>
     <string name="usage_insights">Usage Insights</string>
@@ -31,7 +31,7 @@
     <string name="contact_permission_missing_hint">Grant contact access to call or message contacts from search.</string>
     <string name="onboarding_default_launcher_settings_unavailable">Unable to open launcher settings on this device. Please set TALauncher as your default home app from system settings.</string>
     <string-array name="motivational_quotes">
-        <item>Every tap is a choice—make it count.</item>
+        <item>Every tap is a choiceâ€”make it count.</item>
         <item>Stay focused on what truly matters right now.</item>
         <item>Small mindful actions create lasting change.</item>
         <item>Progress is made one focused moment at a time.</item>
@@ -217,8 +217,6 @@
     <string name="onboarding_step_default_desc">Make %1$s your default home screen</string>
     <string name="onboarding_step_usage_title">Usage Statistics Permission</string>
     <string name="onboarding_step_usage_desc">Allow access to usage stats to show insights and mindful nudges</string>
-    <string name="onboarding_step_notifications_title">Allow Notifications</string>
-    <string name="onboarding_step_notifications_desc">Enable gentle reminders when time limits expire</string>
     <string name="onboarding_step_contacts_title">Contacts Permission</string>
     <string name="onboarding_step_contacts_desc">Let TALauncher access your contacts for quick calling</string>
     <string name="onboarding_step_location_title">Location Permission</string>
@@ -228,7 +226,6 @@
     <string name="completed">Completed</string>
     <string name="onboarding_action_set_default">Set as Default</string>
     <string name="onboarding_action_grant_permission">Grant Permission</string>
-    <string name="onboarding_action_allow_notifications">Allow Notifications</string>
     <string name="skip_for_now">Skip for now</string>
     <string name="next">Next</string>
     <string name="back">Back</string>


### PR DESCRIPTION
- **onboarding: constrain appearance preview size and preserve aspect ratio; make ModernBackdrop size overridable**
- **onboarding: accordion sections before preview (single-open), smaller phone-like preview keeping aspect ratio; default preview glassmorphism; remove obsolete notifications strings; ArrowBack automirrored**
- **onboarding: accordion polish (clickable row fix), top-level AppearanceSection, import fixes**
