### PR TITLE
Adjust onboarding appearance preview layout

### DIFF
--- a/app/src/main/java/com/talauncher/ui/components/ModernComponents.kt
+++ b/app/src/main/java/com/talauncher/ui/components/ModernComponents.kt
@@ -553,9 +553,7 @@ fun ModernBackdrop(
     val wallpaperAlpha = if (showWallpaper) opacity.coerceIn(0f, 1f) else 1f
 
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .then(modifier)
+        modifier = modifier
             .background(backgroundColorValue)
     ) {
         if (showWallpaper && wallpaperPainter != null) {

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -137,7 +137,9 @@ fun HomeScreen(
         backgroundColor = uiState.backgroundColor,
         opacity = uiState.backgroundOpacity,
         customWallpaperPath = uiState.customWallpaperPath,
-        modifier = Modifier.systemBarsPadding()
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(

--- a/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
@@ -359,6 +359,12 @@ private fun AppearanceStep(
         Text(stringResource(R.string.color_palette_preview_title), style = MaterialTheme.typography.titleMedium)
         Spacer(Modifier.height(8.dp))
 
+        val previewApps = listOf(
+            "Calendar" to "com.android.calendar",
+            "Messages" to "com.android.messaging",
+            "Notes" to "com.example.notes"
+        )
+
         com.talauncher.ui.components.ModernBackdrop(
             showWallpaper = showWallpaper,
             blurAmount = wallpaperBlurAmount,
@@ -366,14 +372,25 @@ private fun AppearanceStep(
             opacity = backgroundOpacity,
             customWallpaperPath = customWallpaperPath,
             modifier = Modifier
-                .fillMaxWidth(0.72f)
-                .aspectRatio(9f / 19.5f)
+                .align(Alignment.CenterHorizontally)
+                .fillMaxWidth()
+                .widthIn(max = 360.dp)
+                .heightIn(max = 240.dp)
                 .clip(RoundedCornerShape(16.dp))
         ) {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.padding(8.dp)) {
-                ModernAppItem(appName = "Calendar", packageName = "com.android.calendar", onClick = {}, appIconStyle = selectedIconStyle, enableGlassmorphism = true)
-                ModernAppItem(appName = "Messages", packageName = "com.android.messaging", onClick = {}, appIconStyle = selectedIconStyle, enableGlassmorphism = true)
-                ModernAppItem(appName = "Notes", packageName = "com.example.notes", onClick = {}, appIconStyle = selectedIconStyle, enableGlassmorphism = true)
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(12.dp)
+            ) {
+                previewApps.take(3).forEach { (appName, packageName) ->
+                    ModernAppItem(
+                        appName = appName,
+                        packageName = packageName,
+                        onClick = {},
+                        appIconStyle = selectedIconStyle,
+                        enableGlassmorphism = true
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- allow `ModernBackdrop` to respect the size passed in by its callers
- ensure the home screen backdrop still fills the entire screen after the sizing change
- shrink the onboarding appearance preview and cap the preview list to three items so the wallpaper sample is not overly tall

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfde6447748321bdb950f17882c0c5