### PR TITLE
[WIP] Add app section display settings

### DIFF
--- a/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
+++ b/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
@@ -46,5 +46,18 @@ data class LauncherSettings(
     val accentColor: String? = null, // Custom accent color override (hex)
     val fontScale: Float = 1.0f, // Text size scaling factor (0.8-1.4)
     val enableAnimations: Boolean = true, // Enable smooth UI animations
-    val cardElevation: Int = 2 // Card elevation in dp (0-8)
+    val cardElevation: Int = 2, // Card elevation in dp (0-8)
+
+    // App section display settings
+    val pinnedAppsLayout: AppSectionLayoutOption = AppSectionLayoutOption.LIST,
+    val pinnedAppsDisplayStyle: AppDisplayStyleOption = AppDisplayStyleOption.ICON_AND_TEXT,
+    val pinnedAppsIconColor: IconColorOption = IconColorOption.ORIGINAL,
+
+    val recentAppsLayout: AppSectionLayoutOption = AppSectionLayoutOption.LIST,
+    val recentAppsDisplayStyle: AppDisplayStyleOption = AppDisplayStyleOption.ICON_AND_TEXT,
+    val recentAppsIconColor: IconColorOption = IconColorOption.ORIGINAL,
+
+    val allAppsLayout: AppSectionLayoutOption = AppSectionLayoutOption.LIST,
+    val allAppsDisplayStyle: AppDisplayStyleOption = AppDisplayStyleOption.ICON_AND_TEXT,
+    val allAppsIconColor: IconColorOption = IconColorOption.ORIGINAL
 )

--- a/app/src/main/java/com/talauncher/data/model/SettingsOptions.kt
+++ b/app/src/main/java/com/talauncher/data/model/SettingsOptions.kt
@@ -103,3 +103,50 @@ enum class UiDensityOption(val label: String) {
         }
     }
 }
+
+enum class AppSectionLayoutOption(val label: String, val columns: Int) {
+    LIST("List (1 per row)", 1),
+    GRID_3("Grid (3 per row)", 3),
+    GRID_4("Grid (4 per row)", 4);
+
+    val storageValue: String
+        get() = name
+
+    companion object {
+        fun fromStorageValue(value: String?): AppSectionLayoutOption {
+            val normalized = value?.lowercase(Locale.US)
+            return entries.firstOrNull { it.name.lowercase(Locale.US) == normalized } ?: LIST
+        }
+    }
+}
+
+enum class AppDisplayStyleOption(val label: String) {
+    ICON_ONLY("Icon only"),
+    ICON_AND_TEXT("Icon and text"),
+    TEXT_ONLY("Text only");
+
+    val storageValue: String
+        get() = name
+
+    companion object {
+        fun fromStorageValue(value: String?): AppDisplayStyleOption {
+            val normalized = value?.lowercase(Locale.US)
+            return entries.firstOrNull { it.name.lowercase(Locale.US) == normalized } ?: ICON_AND_TEXT
+        }
+    }
+}
+
+enum class IconColorOption(val label: String) {
+    ORIGINAL("Original colors"),
+    MONOCHROME("Monochrome");
+
+    val storageValue: String
+        get() = name
+
+    companion object {
+        fun fromStorageValue(value: String?): IconColorOption {
+            val normalized = value?.lowercase(Locale.US)
+            return entries.firstOrNull { it.name.lowercase(Locale.US) == normalized } ?: ORIGINAL
+        }
+    }
+}

--- a/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
@@ -8,6 +8,9 @@ import com.talauncher.data.model.ThemeModeOption
 import com.talauncher.data.model.UiDensityOption
 import com.talauncher.data.model.WeatherDisplayOption
 import com.talauncher.data.model.WeatherTemperatureUnit
+import com.talauncher.data.model.AppSectionLayoutOption
+import com.talauncher.data.model.AppDisplayStyleOption
+import com.talauncher.data.model.IconColorOption
 import kotlinx.coroutines.flow.Flow
 
 class SettingsRepository(private val settingsDao: SettingsDao) {
@@ -171,5 +174,51 @@ class SettingsRepository(private val settingsDao: SettingsDao) {
     suspend fun updateAnimationsEnabled(enabled: Boolean) {
         val settings = getSettingsSync()
         updateSettings(settings.copy(enableAnimations = enabled))
+    }
+
+    // App section display settings update methods
+    suspend fun updatePinnedAppsLayout(layout: AppSectionLayoutOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(pinnedAppsLayout = layout))
+    }
+
+    suspend fun updatePinnedAppsDisplayStyle(style: AppDisplayStyleOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(pinnedAppsDisplayStyle = style))
+    }
+
+    suspend fun updatePinnedAppsIconColor(color: IconColorOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(pinnedAppsIconColor = color))
+    }
+
+    suspend fun updateRecentAppsLayout(layout: AppSectionLayoutOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(recentAppsLayout = layout))
+    }
+
+    suspend fun updateRecentAppsDisplayStyle(style: AppDisplayStyleOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(recentAppsDisplayStyle = style))
+    }
+
+    suspend fun updateRecentAppsIconColor(color: IconColorOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(recentAppsIconColor = color))
+    }
+
+    suspend fun updateAllAppsLayout(layout: AppSectionLayoutOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(allAppsLayout = layout))
+    }
+
+    suspend fun updateAllAppsDisplayStyle(style: AppDisplayStyleOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(allAppsDisplayStyle = style))
+    }
+
+    suspend fun updateAllAppsIconColor(color: IconColorOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(allAppsIconColor = color))
     }
 }

--- a/app/src/main/java/com/talauncher/ui/settings/AppSectionsSettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/AppSectionsSettingsScreen.kt
@@ -1,0 +1,228 @@
+package com.talauncher.ui.settings
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.talauncher.R
+import com.talauncher.data.model.AppSectionLayoutOption
+import com.talauncher.data.model.AppDisplayStyleOption
+import com.talauncher.data.model.IconColorOption
+import com.talauncher.ui.components.CollapsibleSection
+import com.talauncher.ui.components.CollapsibleSectionContainer
+import com.talauncher.ui.components.SettingsLazyColumn
+import com.talauncher.ui.components.SliderSetting
+import kotlin.math.roundToInt
+
+@Composable
+fun AppSectionsSettingsScreen(
+    // Pinned Apps settings
+    pinnedAppsLayout: AppSectionLayoutOption,
+    onUpdatePinnedAppsLayout: (AppSectionLayoutOption) -> Unit,
+    pinnedAppsDisplayStyle: AppDisplayStyleOption,
+    onUpdatePinnedAppsDisplayStyle: (AppDisplayStyleOption) -> Unit,
+    pinnedAppsIconColor: IconColorOption,
+    onUpdatePinnedAppsIconColor: (IconColorOption) -> Unit,
+
+    // Recent Apps settings
+    recentAppsLayout: AppSectionLayoutOption,
+    onUpdateRecentAppsLayout: (AppSectionLayoutOption) -> Unit,
+    recentAppsDisplayStyle: AppDisplayStyleOption,
+    onUpdateRecentAppsDisplayStyle: (AppDisplayStyleOption) -> Unit,
+    recentAppsIconColor: IconColorOption,
+    onUpdateRecentAppsIconColor: (IconColorOption) -> Unit,
+    recentAppsLimit: Int,
+    onUpdateRecentAppsLimit: (Int) -> Unit,
+
+    // All Apps settings
+    allAppsLayout: AppSectionLayoutOption,
+    onUpdateAllAppsLayout: (AppSectionLayoutOption) -> Unit,
+    allAppsDisplayStyle: AppDisplayStyleOption,
+    onUpdateAllAppsDisplayStyle: (AppDisplayStyleOption) -> Unit,
+    allAppsIconColor: IconColorOption,
+    onUpdateAllAppsIconColor: (IconColorOption) -> Unit
+) {
+    val sections = listOf(
+        CollapsibleSection(
+            id = "pinned_apps",
+            title = stringResource(R.string.settings_pinned_apps)
+        ) {
+            AppSectionContent(
+                layout = pinnedAppsLayout,
+                onUpdateLayout = onUpdatePinnedAppsLayout,
+                displayStyle = pinnedAppsDisplayStyle,
+                onUpdateDisplayStyle = onUpdatePinnedAppsDisplayStyle,
+                iconColor = pinnedAppsIconColor,
+                onUpdateIconColor = onUpdatePinnedAppsIconColor
+            )
+        },
+        CollapsibleSection(
+            id = "recent_apps",
+            title = stringResource(R.string.settings_recent_apps)
+        ) {
+            AppSectionContent(
+                layout = recentAppsLayout,
+                onUpdateLayout = onUpdateRecentAppsLayout,
+                displayStyle = recentAppsDisplayStyle,
+                onUpdateDisplayStyle = onUpdateRecentAppsDisplayStyle,
+                iconColor = recentAppsIconColor,
+                onUpdateIconColor = onUpdateRecentAppsIconColor,
+                showRecentAppsLimit = true,
+                recentAppsLimit = recentAppsLimit,
+                onUpdateRecentAppsLimit = onUpdateRecentAppsLimit
+            )
+        },
+        CollapsibleSection(
+            id = "all_apps",
+            title = stringResource(R.string.settings_all_apps)
+        ) {
+            AppSectionContent(
+                layout = allAppsLayout,
+                onUpdateLayout = onUpdateAllAppsLayout,
+                displayStyle = allAppsDisplayStyle,
+                onUpdateDisplayStyle = onUpdateAllAppsDisplayStyle,
+                iconColor = allAppsIconColor,
+                onUpdateIconColor = onUpdateAllAppsIconColor
+            )
+        }
+    )
+
+    SettingsLazyColumn {
+        item {
+            CollapsibleSectionContainer(
+                sections = sections,
+                initialExpandedId = "pinned_apps"
+            )
+        }
+    }
+}
+
+@Composable
+private fun AppSectionContent(
+    layout: AppSectionLayoutOption,
+    onUpdateLayout: (AppSectionLayoutOption) -> Unit,
+    displayStyle: AppDisplayStyleOption,
+    onUpdateDisplayStyle: (AppDisplayStyleOption) -> Unit,
+    iconColor: IconColorOption,
+    onUpdateIconColor: (IconColorOption) -> Unit,
+    showRecentAppsLimit: Boolean = false,
+    recentAppsLimit: Int = 0,
+    onUpdateRecentAppsLimit: ((Int) -> Unit)? = null
+) {
+    // Layout Section
+    Text(
+        text = stringResource(R.string.settings_section_layout),
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.padding(bottom = 4.dp)
+    )
+    Text(
+        text = stringResource(R.string.settings_section_layout_subtitle),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        AppSectionLayoutOption.entries.forEach { option ->
+            FilterChip(
+                selected = layout == option,
+                onClick = { onUpdateLayout(option) },
+                label = { Text(option.label) },
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    // Display Style Section
+    Text(
+        text = stringResource(R.string.settings_display_style),
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.padding(bottom = 4.dp)
+    )
+    Text(
+        text = stringResource(R.string.settings_display_style_subtitle),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        AppDisplayStyleOption.entries.forEach { option ->
+            FilterChip(
+                selected = displayStyle == option,
+                onClick = { onUpdateDisplayStyle(option) },
+                label = { Text(option.label) },
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+
+    // Icon Color Section (only show if display style includes icons)
+    if (displayStyle != AppDisplayStyleOption.TEXT_ONLY) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = stringResource(R.string.settings_icon_color),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(bottom = 4.dp)
+        )
+        Text(
+            text = stringResource(R.string.settings_icon_color_subtitle),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            IconColorOption.entries.forEach { option ->
+                FilterChip(
+                    selected = iconColor == option,
+                    onClick = { onUpdateIconColor(option) },
+                    label = { Text(option.label) },
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+
+    // Recent Apps Limit Slider (only for recent apps section)
+    if (showRecentAppsLimit && onUpdateRecentAppsLimit != null) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        var recentAppsValue by remember(recentAppsLimit) {
+            mutableStateOf(recentAppsLimit.toFloat())
+        }
+
+        val recentCount = recentAppsValue.roundToInt()
+        val recentSummary = when {
+            recentCount == 0 -> stringResource(R.string.settings_recent_apps_limit_hidden)
+            recentCount == 1 -> stringResource(R.string.settings_recent_apps_limit_summary_single)
+            else -> stringResource(R.string.settings_recent_apps_limit_summary_plural, recentCount)
+        }
+
+        SliderSetting(
+            label = stringResource(R.string.settings_recent_apps_limit_title),
+            value = recentAppsValue,
+            onValueChange = { recentAppsValue = it },
+            valueRange = 0f..10f,
+            steps = 9,
+            onValueChangeFinished = {
+                onUpdateRecentAppsLimit(recentAppsValue.roundToInt())
+            },
+            valueLabel = recentSummary
+        )
+    }
+}

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
@@ -30,6 +30,7 @@ fun SettingsScreen(
     var selectedTab by remember { mutableIntStateOf(0) }
     val tabs = listOf(
         stringResource(R.string.settings_tab_general),
+        stringResource(R.string.settings_tab_app_sections),
         stringResource(R.string.settings_tab_ui_theme),
         stringResource(R.string.settings_tab_distracting_apps),
         stringResource(R.string.settings_tab_usage_insights)
@@ -63,7 +64,7 @@ fun SettingsScreen(
     }
 
     LaunchedEffect(selectedTab) {
-        if (selectedTab != 2) {
+        if (selectedTab != 3) {
             viewModel.clearSearchQuery()
         }
     }
@@ -122,7 +123,29 @@ fun SettingsScreen(
                 buildBranch = uiState.buildBranch,
                 buildTime = uiState.buildTime
             )
-            1 -> UIThemeSettingsScreen(
+            1 -> AppSectionsSettingsScreen(
+                pinnedAppsLayout = uiState.pinnedAppsLayout,
+                onUpdatePinnedAppsLayout = viewModel::updatePinnedAppsLayout,
+                pinnedAppsDisplayStyle = uiState.pinnedAppsDisplayStyle,
+                onUpdatePinnedAppsDisplayStyle = viewModel::updatePinnedAppsDisplayStyle,
+                pinnedAppsIconColor = uiState.pinnedAppsIconColor,
+                onUpdatePinnedAppsIconColor = viewModel::updatePinnedAppsIconColor,
+                recentAppsLayout = uiState.recentAppsLayout,
+                onUpdateRecentAppsLayout = viewModel::updateRecentAppsLayout,
+                recentAppsDisplayStyle = uiState.recentAppsDisplayStyle,
+                onUpdateRecentAppsDisplayStyle = viewModel::updateRecentAppsDisplayStyle,
+                recentAppsIconColor = uiState.recentAppsIconColor,
+                onUpdateRecentAppsIconColor = viewModel::updateRecentAppsIconColor,
+                recentAppsLimit = uiState.recentAppsLimit,
+                onUpdateRecentAppsLimit = viewModel::updateRecentAppsLimit,
+                allAppsLayout = uiState.allAppsLayout,
+                onUpdateAllAppsLayout = viewModel::updateAllAppsLayout,
+                allAppsDisplayStyle = uiState.allAppsDisplayStyle,
+                onUpdateAllAppsDisplayStyle = viewModel::updateAllAppsDisplayStyle,
+                allAppsIconColor = uiState.allAppsIconColor,
+                onUpdateAllAppsIconColor = viewModel::updateAllAppsIconColor
+            )
+            2 -> UIThemeSettingsScreen(
                 backgroundColor = uiState.backgroundColor,
                 onUpdateBackgroundColor = viewModel::updateBackgroundColor,
                 showWallpaper = uiState.showWallpaper,
@@ -154,7 +177,7 @@ fun SettingsScreen(
                 enableAnimations = uiState.enableAnimations,
                 onToggleAnimations = viewModel::updateAnimationsEnabled
             )
-            2 -> DistractingAppsSettingsScreen(
+            3 -> DistractingAppsSettingsScreen(
                 uiState = uiState,
                 viewModel = viewModel,
                 onEditApp = { app, timeLimit, usesDefault ->
@@ -163,7 +186,7 @@ fun SettingsScreen(
                     editingUsesDefault = usesDefault
                 }
             )
-            3 -> {
+            4 -> {
                 val insightsViewModel: InsightsViewModel = viewModel {
                     InsightsViewModel(viewModel.usageStatsHelper, viewModel.permissionsHelper)
                 }

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
@@ -10,6 +10,9 @@ import com.talauncher.data.model.ThemeModeOption
 import com.talauncher.data.model.UiDensityOption
 import com.talauncher.data.model.WeatherDisplayOption
 import com.talauncher.data.model.WeatherTemperatureUnit
+import com.talauncher.data.model.AppSectionLayoutOption
+import com.talauncher.data.model.AppDisplayStyleOption
+import com.talauncher.data.model.IconColorOption
 import com.talauncher.data.repository.AppRepository
 import com.talauncher.data.repository.SettingsRepository
 import com.talauncher.utils.PermissionsHelper
@@ -84,6 +87,20 @@ class SettingsViewModel(
                     uiDensity = settings?.uiDensity ?: UiDensityOption.COMPACT,
                     enableAnimations = settings?.enableAnimations ?: true,
                     customWallpaperPath = settings?.customWallpaperPath,
+
+                    // App section display settings
+                    pinnedAppsLayout = settings?.pinnedAppsLayout ?: AppSectionLayoutOption.LIST,
+                    pinnedAppsDisplayStyle = settings?.pinnedAppsDisplayStyle ?: AppDisplayStyleOption.ICON_AND_TEXT,
+                    pinnedAppsIconColor = settings?.pinnedAppsIconColor ?: IconColorOption.ORIGINAL,
+
+                    recentAppsLayout = settings?.recentAppsLayout ?: AppSectionLayoutOption.LIST,
+                    recentAppsDisplayStyle = settings?.recentAppsDisplayStyle ?: AppDisplayStyleOption.ICON_AND_TEXT,
+                    recentAppsIconColor = settings?.recentAppsIconColor ?: IconColorOption.ORIGINAL,
+
+                    allAppsLayout = settings?.allAppsLayout ?: AppSectionLayoutOption.LIST,
+                    allAppsDisplayStyle = settings?.allAppsDisplayStyle ?: AppDisplayStyleOption.ICON_AND_TEXT,
+                    allAppsIconColor = settings?.allAppsIconColor ?: IconColorOption.ORIGINAL,
+
                     availableApps = allInstalledApps,
                     isLoading = false
                 )
@@ -286,6 +303,60 @@ class SettingsViewModel(
         }
     }
 
+    // App section display settings update methods
+    fun updatePinnedAppsLayout(layout: AppSectionLayoutOption) {
+        viewModelScope.launch {
+            settingsRepository.updatePinnedAppsLayout(layout)
+        }
+    }
+
+    fun updatePinnedAppsDisplayStyle(style: AppDisplayStyleOption) {
+        viewModelScope.launch {
+            settingsRepository.updatePinnedAppsDisplayStyle(style)
+        }
+    }
+
+    fun updatePinnedAppsIconColor(color: IconColorOption) {
+        viewModelScope.launch {
+            settingsRepository.updatePinnedAppsIconColor(color)
+        }
+    }
+
+    fun updateRecentAppsLayout(layout: AppSectionLayoutOption) {
+        viewModelScope.launch {
+            settingsRepository.updateRecentAppsLayout(layout)
+        }
+    }
+
+    fun updateRecentAppsDisplayStyle(style: AppDisplayStyleOption) {
+        viewModelScope.launch {
+            settingsRepository.updateRecentAppsDisplayStyle(style)
+        }
+    }
+
+    fun updateRecentAppsIconColor(color: IconColorOption) {
+        viewModelScope.launch {
+            settingsRepository.updateRecentAppsIconColor(color)
+        }
+    }
+
+    fun updateAllAppsLayout(layout: AppSectionLayoutOption) {
+        viewModelScope.launch {
+            settingsRepository.updateAllAppsLayout(layout)
+        }
+    }
+
+    fun updateAllAppsDisplayStyle(style: AppDisplayStyleOption) {
+        viewModelScope.launch {
+            settingsRepository.updateAllAppsDisplayStyle(style)
+        }
+    }
+
+    fun updateAllAppsIconColor(color: IconColorOption) {
+        viewModelScope.launch {
+            settingsRepository.updateAllAppsIconColor(color)
+        }
+    }
 
 
     fun updateSearchQuery(query: String) {
@@ -345,5 +416,18 @@ data class SettingsUiState(
     val enableGlassmorphism: Boolean = true,
     val uiDensity: UiDensityOption = UiDensityOption.COMPACT,
     val enableAnimations: Boolean = true,
-    val customWallpaperPath: String? = null
+    val customWallpaperPath: String? = null,
+
+    // App section display settings
+    val pinnedAppsLayout: AppSectionLayoutOption = AppSectionLayoutOption.LIST,
+    val pinnedAppsDisplayStyle: AppDisplayStyleOption = AppDisplayStyleOption.ICON_AND_TEXT,
+    val pinnedAppsIconColor: IconColorOption = IconColorOption.ORIGINAL,
+
+    val recentAppsLayout: AppSectionLayoutOption = AppSectionLayoutOption.LIST,
+    val recentAppsDisplayStyle: AppDisplayStyleOption = AppDisplayStyleOption.ICON_AND_TEXT,
+    val recentAppsIconColor: IconColorOption = IconColorOption.ORIGINAL,
+
+    val allAppsLayout: AppSectionLayoutOption = AppSectionLayoutOption.LIST,
+    val allAppsDisplayStyle: AppDisplayStyleOption = AppDisplayStyleOption.ICON_AND_TEXT,
+    val allAppsIconColor: IconColorOption = IconColorOption.ORIGINAL
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,7 @@
 
     <!-- Settings General -->
     <string name="settings_tab_general">General</string>
+    <string name="settings_tab_app_sections">App Sections</string>
     <string name="settings_tab_ui_theme">UI &amp; Theme</string>
     <string name="settings_tab_distracting_apps">Distracting Apps</string>
     <string name="settings_tab_usage_insights">Usage Insights</string>
@@ -148,6 +149,29 @@
     <string name="settings_build_commit">Commit: %1$s</string>
     <string name="settings_build_branch">Branch: %1$s</string>
     <string name="settings_build_time">Built: %1$s</string>
+
+    <!-- App Section Display Settings -->
+    <string name="settings_app_sections">App Sections</string>
+    <string name="settings_pinned_apps">Pinned Apps</string>
+    <string name="settings_recent_apps">Recent Apps</string>
+    <string name="settings_all_apps">All Apps</string>
+
+    <string name="settings_section_layout">Layout</string>
+    <string name="settings_section_layout_subtitle">Choose how apps are arranged</string>
+    <string name="settings_layout_list">List (1 per row)</string>
+    <string name="settings_layout_grid_3">Grid (3 per row)</string>
+    <string name="settings_layout_grid_4">Grid (4 per row)</string>
+
+    <string name="settings_display_style">Display Style</string>
+    <string name="settings_display_style_subtitle">Choose what to show for each app</string>
+    <string name="settings_display_icon_only">Icon only</string>
+    <string name="settings_display_icon_and_text">Icon and text</string>
+    <string name="settings_display_text_only">Text only</string>
+
+    <string name="settings_icon_color">Icon Color</string>
+    <string name="settings_icon_color_subtitle">Choose icon color style</string>
+    <string name="settings_icon_color_original">Original colors</string>
+    <string name="settings_icon_color_monochrome">Monochrome</string>
 
     <!-- Distracting Apps Settings -->
     <string name="settings_default_time_limit">Default Time Limit</string>


### PR DESCRIPTION
## Overview
This PR adds comprehensive display settings for each app section (Pinned, Recent, All Apps) with collapsible UI.

## Completed
- ✅ Add new enum models for layout (list/grid-3/grid-4), display style (icon-only/icon-text/text-only), and icon color (original/monochrome)
- ✅ Create AppSectionsSettingsScreen with collapsible sections for each app section
- ✅ Update LauncherSettings data model to store per-section preferences
- ✅ Add ViewModel and Repository methods for all section settings
- ✅ Move recent apps limit slider into Recent Apps section
- ✅ Add string resources for all new options
- ✅ Successfully builds with no compilation errors

## TODO (Remaining Work)
- [ ] Create grid layout components for 3x and 4x layouts
- [ ] Update HomeScreen to use the new section-specific settings
- [ ] Update HomeViewModel to expose settings to HomeScreen
- [ ] Update onboarding to set defaults for all sections based on user choices
- [ ] Remove global icon display toggle (now per-section)
- [ ] Test all combinations and edge cases

## Notes
Settings screen is complete and functional. Remaining work is to:
1. Implement grid layouts in HomeScreen
2. Wire up the settings to actually control how each section displays
3. Update onboarding flow to initialize these settings

## Preview
New "App Sections" tab in settings with collapsible sections for:
- Pinned Apps (layout, display style, icon color)
- Recent Apps (layout, display style, icon color, + limit slider moved here)
- All Apps (layout, display style, icon color)

Icon color options only appear when display style includes icons.