### PR TITLE
Bump schema version and fix sidebar wave effect at high spread values

### DIFF
--- a/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
+++ b/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
@@ -13,7 +13,7 @@ import com.talauncher.data.model.SearchInteractionEntity
 
 @Database(
     entities = [AppInfo::class, LauncherSettings::class, AppSession::class, SearchInteractionEntity::class],
-    version = 19,
+    version = 20,
     exportSchema = false
 )
 abstract class LauncherDatabase : RoomDatabase() {

--- a/app/src/main/java/com/talauncher/ui/home/AlphabetIndexComponent.kt
+++ b/app/src/main/java/com/talauncher/ui/home/AlphabetIndexComponent.kt
@@ -182,8 +182,10 @@ private fun AlphabetIndexItem(
         else if (waveSpread <= 0f) {
             if (distance == 0) 1f else 0f
         } else {
-            // Smooth exponential falloff
-            kotlin.math.exp(-distance / waveSpread)
+            val rawInfluence = kotlin.math.exp(-distance / waveSpread)
+            // Apply minimum threshold to prevent too many items from being affected
+            // This is especially important for high waveSpread values (3.0+)
+            if (rawInfluence < 0.1f) 0f else rawInfluence
         }
     }
 
@@ -425,7 +427,10 @@ private fun EnhancedAlphabetItem(
         else if (waveSpread <= 0f) {
             if (distance == 0) 1f else 0f
         } else {
-            kotlin.math.exp(-distance / waveSpread)
+            val rawInfluence = kotlin.math.exp(-distance / waveSpread)
+            // Apply minimum threshold to prevent too many items from being affected
+            // This is especially important for high waveSpread values (3.0+)
+            if (rawInfluence < 0.1f) 0f else rawInfluence
         }
     }
     val influence = if (!isEnabled) 0f else influenceBase


### PR DESCRIPTION
## Summary
- Bump database schema version from 19 to 20
- Fix sidebar current item clarity when waveSpread is set to 3.0-4.0

## Changes
- Increment database schema version in LauncherDatabase.kt
- Add minimum influence threshold (0.1) to sidebar wave calculations
- Applied to both AlphabetIndexItem and EnhancedAlphabetItem components

## Why
At high waveSpread values (3.0+), too many sidebar letters were being affected by the wave effect, making it unclear which letter is currently active. The 0.1 minimum threshold ensures only nearby items are visually affected.

## Testing
- Tested with waveSpread values from 1.0 to 4.0
- Verified current item is clearly visible at all spread values