### PR TITLE
Fix fast-scroll grid alignment, dynamic section sizing, and per-item targeting

### DIFF
--- a/app/src/main/java/com/talauncher/ui/components/AppGridItems.kt
+++ b/app/src/main/java/com/talauncher/ui/components/AppGridItems.kt
@@ -23,10 +23,11 @@ fun AppGridItemIconOnly(
     app: AppInfo,
     iconStyle: AppIconStyleOption,
     onClick: () -> Unit,
-    onLongClick: (() -> Unit)?
+    onLongClick: (() -> Unit)?,
+    modifier: Modifier = Modifier
 ) {
     Surface(
-        modifier = Modifier
+        modifier = modifier
             .aspectRatio(1f)
             .combinedClickable(
                 onClick = onClick,
@@ -60,10 +61,11 @@ fun AppGridItemWithText(
     app: AppInfo,
     iconStyle: AppIconStyleOption,
     onClick: () -> Unit,
-    onLongClick: (() -> Unit)?
+    onLongClick: (() -> Unit)?,
+    modifier: Modifier = Modifier
 ) {
     Surface(
-        modifier = Modifier
+        modifier = modifier
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = onLongClick
@@ -105,10 +107,11 @@ fun AppGridItemWithText(
 fun AppGridItemTextOnly(
     app: AppInfo,
     onClick: () -> Unit,
-    onLongClick: (() -> Unit)?
+    onLongClick: (() -> Unit)?,
+    modifier: Modifier = Modifier
 ) {
     Surface(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .combinedClickable(
                 onClick = onClick,

--- a/app/src/main/java/com/talauncher/ui/home/AlphabetIndexComponent.kt
+++ b/app/src/main/java/com/talauncher/ui/home/AlphabetIndexComponent.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.platform.LocalDensity
+// Removed duplicate LocalDensity import
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -251,6 +251,7 @@ fun EnhancedAlphabetFastScroller(
     isEnabled: Boolean,
     modifier: Modifier = Modifier,
     onScrollToIndex: (Int) -> Unit = {},
+    onActiveGlobalIndexChanged: (Int?) -> Unit = {},
     // Sidebar styling controls
     activeScale: Float = 1.4f,
     popOutDp: Float = 16f,
@@ -313,6 +314,8 @@ fun EnhancedAlphabetFastScroller(
                                     railBottomPadding = PrimerSpacing.md.toPx(),
                                     onScrollToIndex = onScrollToIndex
                                 )
+                                // Notify active target for grid highlight
+                                onActiveGlobalIndexChanged(controller.state.value.currentTarget?.globalIndex)
                             } catch (e: Exception) {
                                 android.util.Log.e("EnhancedFastScroller", "Error handling initial touch", e)
                             }
@@ -328,6 +331,8 @@ fun EnhancedAlphabetFastScroller(
                                             railBottomPadding = PrimerSpacing.md.toPx(),
                                             onScrollToIndex = onScrollToIndex
                                         )
+                                        // Notify active target for grid highlight
+                                        onActiveGlobalIndexChanged(controller.state.value.currentTarget?.globalIndex)
                                         change.consume()
                                     } catch (e: Exception) {
                                         android.util.Log.e("EnhancedFastScroller", "Error during drag", e)
@@ -338,6 +343,7 @@ fun EnhancedAlphabetFastScroller(
                             } finally {
                                 try {
                                     controller.onTouchEnd()
+                                    onActiveGlobalIndexChanged(null)
                                 } catch (e: Exception) {
                                     android.util.Log.e("EnhancedFastScroller", "Error in onTouchEnd", e)
                                 }

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -71,6 +71,7 @@ import com.talauncher.utils.PermissionsHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.withContext
+import com.talauncher.ui.home.ScrollIndexMapper
 
 private fun UiDensityOption.toUiDensity(): UiDensity = when (this) {
     UiDensityOption.COMPACT -> UiDensity.Compact
@@ -264,6 +265,7 @@ fun HomeScreen(
                 // Apps Section with Recent Apps and Alphabet Index
                 val listState = rememberLazyListState()
                 val scope = rememberCoroutineScope()
+                var activeGlobalIndex by remember { mutableStateOf<Int?>(null) }
 
                 // Handle alphabet index scrolling
                 LaunchedEffect(uiState.alphabetIndexActiveKey) {
@@ -306,17 +308,19 @@ fun HomeScreen(
                     ) {
                         // Pinned Apps Section
                         if (uiState.pinnedApps.isNotEmpty()) {
-                            item {
-                                Text(
-                                    text = "📌 Pinned",
-                                    style = MaterialTheme.typography.titleSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(
-                                        start = PrimerSpacing.md,
-                                        top = PrimerSpacing.md,
-                                        bottom = PrimerSpacing.sm
+                            if (uiState.pinnedAppsLayout == com.talauncher.data.model.AppSectionLayoutOption.LIST) {
+                                item {
+                                    Text(
+                                        text = "📌 Pinned",
+                                        style = MaterialTheme.typography.titleSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier.padding(
+                                            start = PrimerSpacing.md,
+                                            top = PrimerSpacing.md,
+                                            bottom = PrimerSpacing.sm
+                                        )
                                     )
-                                )
+                                }
                             }
 
                             appSectionItems(
@@ -331,27 +335,31 @@ fun HomeScreen(
                                     hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                     viewModel.showAppActionDialog(app)
                                 },
-                                keyPrefix = "pinned"
+                                keyPrefix = "pinned",
+                                activeGlobalIndex = activeGlobalIndex,
+                                sectionGlobalStartIndex = 0
                             )
 
-                            item {
-                                Spacer(modifier = Modifier.height(PrimerSpacing.lg))
+                            if (uiState.pinnedAppsLayout == com.talauncher.data.model.AppSectionLayoutOption.LIST) {
+                                item { Spacer(modifier = Modifier.height(PrimerSpacing.lg)) }
                             }
                         }
 
                         // Recently Used Apps Section
                         if (uiState.recentApps.isNotEmpty()) {
-                            item {
-                                Text(
-                                    text = stringResource(R.string.home_recent_apps_section),
-                                    style = MaterialTheme.typography.titleSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(
-                                        start = PrimerSpacing.md,
-                                        top = PrimerSpacing.md,
-                                        bottom = PrimerSpacing.sm
+                            if (uiState.recentAppsLayout == com.talauncher.data.model.AppSectionLayoutOption.LIST) {
+                                item {
+                                    Text(
+                                        text = stringResource(R.string.home_recent_apps_section),
+                                        style = MaterialTheme.typography.titleSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier.padding(
+                                            start = PrimerSpacing.md,
+                                            top = PrimerSpacing.md,
+                                            bottom = PrimerSpacing.sm
+                                        )
                                     )
-                                )
+                                }
                             }
 
                             appSectionItems(
@@ -366,20 +374,23 @@ fun HomeScreen(
                                     hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                     viewModel.showAppActionDialog(app)
                                 },
-                                keyPrefix = "recent"
+                                keyPrefix = "recent",
+                                activeGlobalIndex = activeGlobalIndex,
+                                sectionGlobalStartIndex = uiState.pinnedApps.size
                             )
-
-                            item {
-                                Spacer(modifier = Modifier.height(PrimerSpacing.lg))
-                                Text(
-                                    text = stringResource(R.string.home_all_apps_section),
-                                    style = MaterialTheme.typography.titleSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(
-                                        start = PrimerSpacing.md,
-                                        bottom = PrimerSpacing.sm
+                            if (uiState.allAppsLayout == com.talauncher.data.model.AppSectionLayoutOption.LIST) {
+                                item {
+                                    Spacer(modifier = Modifier.height(PrimerSpacing.lg))
+                                    Text(
+                                        text = stringResource(R.string.home_all_apps_section),
+                                        style = MaterialTheme.typography.titleSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier.padding(
+                                            start = PrimerSpacing.md,
+                                            bottom = PrimerSpacing.sm
+                                        )
                                     )
-                                )
+                                }
                             }
                         }
 
@@ -396,7 +407,9 @@ fun HomeScreen(
                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                 viewModel.showAppActionDialog(app)
                             },
-                            keyPrefix = "all"
+                            keyPrefix = "all",
+                            activeGlobalIndex = activeGlobalIndex,
+                            sectionGlobalStartIndex = uiState.pinnedApps.size + uiState.recentApps.size
                         )
 
                         if (uiState.hiddenApps.isNotEmpty()) {
@@ -438,14 +451,30 @@ fun HomeScreen(
                             onScrollToIndex = { globalIndex ->
                                 scope.launch {
                                     try {
-                                        // globalIndex already accounts for recent apps section
-                                        // Instant scroll for smooth per-app targeting
-                                        listState.scrollToItem(globalIndex)
+                                        val snapGlobal = ScrollIndexMapper.snapGlobalIndexToRowStart(
+                                            globalIndex = globalIndex,
+                                            pinnedCount = uiState.pinnedApps.size,
+                                            recentCount = uiState.recentApps.size,
+                                            pinnedLayout = uiState.pinnedAppsLayout,
+                                            recentLayout = uiState.recentAppsLayout,
+                                            allLayout = uiState.allAppsLayout
+                                        )
+                                        val adapterIndex = ScrollIndexMapper.globalToAdapterIndex(
+                                            globalIndex = snapGlobal,
+                                            pinnedCount = uiState.pinnedApps.size,
+                                            recentCount = uiState.recentApps.size,
+                                            allCount = uiState.allVisibleApps.size,
+                                            pinnedLayout = uiState.pinnedAppsLayout,
+                                            recentLayout = uiState.recentAppsLayout,
+                                            allLayout = uiState.allAppsLayout
+                                        )
+                                        listState.scrollToItem(adapterIndex)
                                     } catch (e: Exception) {
                                         Log.e("HomeScreen", "Error scrolling to index $globalIndex", e)
                                     }
                                 }
                             },
+                            onActiveGlobalIndexChanged = { idx -> activeGlobalIndex = idx },
                             activeScale = uiState.sidebarActiveScale,
                             popOutDp = uiState.sidebarPopOutDp.toFloat(),
                             waveSpread = uiState.sidebarWaveSpread

--- a/app/src/main/java/com/talauncher/ui/home/ScrollIndexMapper.kt
+++ b/app/src/main/java/com/talauncher/ui/home/ScrollIndexMapper.kt
@@ -1,0 +1,121 @@
+package com.talauncher.ui.home
+
+import com.talauncher.data.model.AppSectionLayoutOption
+import kotlin.math.ceil
+
+/**
+ * Maps global app indices (based on SectionIndex order: Pinned → Recent → All)
+ * to adapter indices in the HomeScreen's LazyColumn, accounting for headers,
+ * spacers, and grid row chunking. Also provides helpers for row snapping.
+ */
+object ScrollIndexMapper {
+
+    /**
+     * Maps a global app index to the adapter index in the LazyColumn.
+     *
+     * - List mode: one adapter item per app (plus optional headers/spacers)
+     * - Grid mode: one adapter item per row; we snap to the row that contains the app
+     *
+     * Headers/spacers are included only for sections that are in LIST layout.
+     */
+    fun globalToAdapterIndex(
+        globalIndex: Int,
+        pinnedCount: Int,
+        recentCount: Int,
+        allCount: Int,
+        pinnedLayout: AppSectionLayoutOption,
+        recentLayout: AppSectionLayoutOption,
+        allLayout: AppSectionLayoutOption
+    ): Int {
+        val pinnedHeader = if (pinnedCount > 0 && pinnedLayout == AppSectionLayoutOption.LIST) 1 else 0
+        val pinnedSpacer = if (pinnedCount > 0 && pinnedLayout == AppSectionLayoutOption.LIST) 1 else 0
+        val pinnedRows = rowsFor(pinnedCount, pinnedLayout)
+
+        val recentHeader = if (recentCount > 0 && recentLayout == AppSectionLayoutOption.LIST) 1 else 0
+        val recentRows = rowsFor(recentCount, recentLayout)
+        // The combined Spacer + "All Apps" title exists only when recent exists and All Apps is LIST
+        val allAppsHeader = if (recentCount > 0 && allLayout == AppSectionLayoutOption.LIST) 1 else 0
+
+        // Compute adapter offsets for section starts
+        val pinnedStartAdapter = 0 + pinnedHeader
+        val recentStartAdapter = pinnedStartAdapter + pinnedRows + pinnedSpacer
+        val allStartAdapter = recentStartAdapter + recentHeader + recentRows + allAppsHeader
+
+        return when {
+            globalIndex < pinnedCount -> {
+                // Pinned
+                val intra = globalIndex
+                pinnedStartAdapter + indexWithinLayoutToAdapterDelta(intra, pinnedLayout)
+            }
+            globalIndex < pinnedCount + recentCount -> {
+                // Recent
+                val intra = globalIndex - pinnedCount
+                recentStartAdapter + indexWithinLayoutToAdapterDelta(intra, recentLayout)
+            }
+            else -> {
+                // All Apps
+                val intra = (globalIndex - pinnedCount - recentCount).coerceAtLeast(0)
+                allStartAdapter + indexWithinLayoutToAdapterDelta(intra, allLayout)
+            }
+        }
+    }
+
+    /**
+     * Returns the row-aligned global index for a given global index in grid layouts.
+     * For list layouts, returns the original index.
+     */
+    fun snapGlobalIndexToRowStart(
+        globalIndex: Int,
+        pinnedCount: Int,
+        recentCount: Int,
+        pinnedLayout: AppSectionLayoutOption,
+        recentLayout: AppSectionLayoutOption,
+        allLayout: AppSectionLayoutOption
+    ): Int {
+        return when {
+            globalIndex < pinnedCount -> {
+                val cols = pinnedLayout.columns
+                if (pinnedLayout == AppSectionLayoutOption.LIST) globalIndex
+                else (globalIndex / cols) * cols
+            }
+            globalIndex < pinnedCount + recentCount -> {
+                val intra = globalIndex - pinnedCount
+                val cols = recentLayout.columns
+                if (recentLayout == AppSectionLayoutOption.LIST) globalIndex
+                else pinnedCount + (intra / cols) * cols
+            }
+            else -> {
+                val intra = globalIndex - pinnedCount - recentCount
+                val cols = allLayout.columns
+                if (allLayout == AppSectionLayoutOption.LIST) globalIndex
+                else pinnedCount + recentCount + (intra / cols) * cols
+            }
+        }
+    }
+
+    /**
+     * Helper: converts an intra-section index into adapter delta based on layout.
+     * List → one per item; Grid → one per row (floor(intra/columns)).
+     */
+    private fun indexWithinLayoutToAdapterDelta(
+        intraIndex: Int,
+        layout: AppSectionLayoutOption
+    ): Int {
+        return when (layout) {
+            AppSectionLayoutOption.LIST -> intraIndex
+            AppSectionLayoutOption.GRID_3, AppSectionLayoutOption.GRID_4 -> intraIndex / layout.columns
+        }
+    }
+
+    /**
+     * Helper: number of adapter rows for a section.
+     */
+    private fun rowsFor(count: Int, layout: AppSectionLayoutOption): Int {
+        return when (layout) {
+            AppSectionLayoutOption.LIST -> count
+            AppSectionLayoutOption.GRID_3, AppSectionLayoutOption.GRID_4 ->
+                if (count == 0) 0 else ceil(count / layout.columns.toFloat()).toInt()
+        }
+    }
+}
+


### PR DESCRIPTION
This PR aligns the fast-scroll rail with actual content, removes extra grid spacing, and adds per-item targeting with a subtle active item "pop" in grid mode.\n\nChanges:\n- Map touch proportionally by total items (not equal sections)\n- Add ScrollIndexMapper for list/grid global→adapter index translation\n- Grid mode: no extra section headers/spacers (continuous content)\n- Row-snapped scrolling for grids to contain the active item\n- Expose active target from scroller; highlight targeted grid cell\n- Keep list headers/spacers only for LIST layouts\n- Minor cleanup (duplicate LocalDensity import)\n\nKey files:\n- app/src/main/java/com/talauncher/domain/usecases/MapTouchToTargetUseCase.kt\n- app/src/main/java/com/talauncher/ui/home/ScrollIndexMapper.kt\n- app/src/main/java/com/talauncher/ui/home/HomeScreen.kt\n- app/src/main/java/com/talauncher/ui/home/AlphabetIndexComponent.kt\n- app/src/main/java/com/talauncher/ui/components/AppGridLayouts.kt\n- app/src/main/java/com/talauncher/ui/components/AppGridItems.kt\n\nBehavior:\n- List: proportional rail mapping with headers/spacers retained\n- Grid: continuous layout without section headers; per-item fast scroll with row snap; active item visually emphasized\n\nFollow-ups (optional):\n- Track current letter during normal scroll via adapter→global mapping\n- Tweak pop animation timing/scale if desired