### PR TITLE
Add fast scroller highlight scale customization

### DIFF
--- a/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
+++ b/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
@@ -13,7 +13,7 @@ import com.talauncher.data.model.SearchInteractionEntity
 
 @Database(
     entities = [AppInfo::class, LauncherSettings::class, AppSession::class, SearchInteractionEntity::class],
-    version = 20,
+    version = 21,
     exportSchema = false
 )
 abstract class LauncherDatabase : RoomDatabase() {
@@ -284,6 +284,14 @@ abstract class LauncherDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_20_21 = object : Migration(20, 21) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE launcher_settings ADD COLUMN fastScrollerActiveItemScale REAL NOT NULL DEFAULT 1.06"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): LauncherDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -308,7 +316,8 @@ abstract class LauncherDatabase : RoomDatabase() {
                     MIGRATION_15_16,
                     MIGRATION_16_17,
                     MIGRATION_17_18,
-                    MIGRATION_18_19
+                    MIGRATION_18_19,
+                    MIGRATION_20_21
                 ).build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
+++ b/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
@@ -67,5 +67,7 @@ data class LauncherSettings(
     // How far the active letter pops out in dp (0 = no offset)
     val sidebarPopOutDp: Int = 16,
     // Controls how far the wave effect spreads to neighbor letters (higher = farther)
-    val sidebarWaveSpread: Float = 1.5f
+    val sidebarWaveSpread: Float = 1.5f,
+    // Scale applied to the app currently highlighted by fast scroll (1.0 = no scale)
+    val fastScrollerActiveItemScale: Float = 1.06f
 )

--- a/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
@@ -240,4 +240,10 @@ class SettingsRepository(private val settingsDao: SettingsDao) {
         val clamped = spread.coerceIn(0.0f, 4.0f)
         updateSettings(settings.copy(sidebarWaveSpread = clamped))
     }
+
+    suspend fun updateFastScrollerActiveItemScale(scale: Float) {
+        val settings = getSettingsSync()
+        val clamped = scale.coerceIn(1.0f, 1.2f)
+        updateSettings(settings.copy(fastScrollerActiveItemScale = clamped))
+    }
 }

--- a/app/src/main/java/com/talauncher/ui/components/AppGridLayouts.kt
+++ b/app/src/main/java/com/talauncher/ui/components/AppGridLayouts.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -28,12 +29,14 @@ fun LazyListScope.appSectionItems(
     onLongClick: ((AppInfo) -> Unit)? = null,
     keyPrefix: String = "",
     activeGlobalIndex: Int? = null,
-    sectionGlobalStartIndex: Int = 0
+    sectionGlobalStartIndex: Int = 0,
+    activeHighlightScale: Float = 1.06f
 ) {
     when (layout) {
         AppSectionLayoutOption.LIST -> {
             // Standard list layout - one app per row
-            items(apps, key = { "${keyPrefix}_${it.packageName}" }) { app ->
+            itemsIndexed(apps, key = { index, app -> "${keyPrefix}_${app.packageName}" }) { index, app ->
+                val isActive = activeGlobalIndex == (sectionGlobalStartIndex + index)
                 AppListItem(
                     app = app,
                     displayStyle = displayStyle,
@@ -41,7 +44,9 @@ fun LazyListScope.appSectionItems(
                     enableGlassmorphism = enableGlassmorphism,
                     uiDensity = uiDensity,
                     onClick = { onClick(app) },
-                    onLongClick = onLongClick?.let { { it(app) } }
+                    onLongClick = onLongClick?.let { { it(app) } },
+                    isActive = isActive,
+                    activeHighlightScale = activeHighlightScale
                 )
             }
         }
@@ -62,7 +67,8 @@ fun LazyListScope.appSectionItems(
                     onClick = onClick,
                     onLongClick = onLongClick,
                     rowStartGlobalIndex = rowStartGlobalIndex,
-                    activeGlobalIndex = activeGlobalIndex
+                    activeGlobalIndex = activeGlobalIndex,
+                    activeHighlightScale = activeHighlightScale
                 )
             }
         }
@@ -80,7 +86,9 @@ private fun AppListItem(
     enableGlassmorphism: Boolean,
     uiDensity: UiDensity,
     onClick: () -> Unit,
-    onLongClick: (() -> Unit)?
+    onLongClick: (() -> Unit)?,
+    isActive: Boolean,
+    activeHighlightScale: Float
 ) {
     val iconStyle = when {
         displayStyle == AppDisplayStyleOption.TEXT_ONLY -> AppIconStyleOption.HIDDEN
@@ -88,11 +96,14 @@ private fun AppListItem(
         else -> AppIconStyleOption.ORIGINAL
     }
 
+    val scale = if (isActive) activeHighlightScale else 1.0f
+
     ModernAppItem(
         appName = app.appName,
         packageName = app.packageName,
         onClick = onClick,
         onLongClick = onLongClick,
+        modifier = Modifier.graphicsLayer(scaleX = scale, scaleY = scale),
         appIconStyle = iconStyle,
         enableGlassmorphism = enableGlassmorphism,
         uiDensity = uiDensity
@@ -111,7 +122,8 @@ private fun AppGridRow(
     onClick: (AppInfo) -> Unit,
     onLongClick: ((AppInfo) -> Unit)?,
     rowStartGlobalIndex: Int,
-    activeGlobalIndex: Int?
+    activeGlobalIndex: Int?,
+    activeHighlightScale: Float
 ) {
     Row(
         modifier = Modifier
@@ -127,7 +139,8 @@ private fun AppGridRow(
                     iconColor = iconColor,
                     onClick = { onClick(app) },
                     onLongClick = onLongClick?.let { { it(app) } },
-                    isActive = (activeGlobalIndex == (rowStartGlobalIndex + colIndex))
+                    isActive = (activeGlobalIndex == (rowStartGlobalIndex + colIndex)),
+                    activeHighlightScale = activeHighlightScale
                 )
             }
         }
@@ -149,7 +162,8 @@ private fun AppGridItem(
     iconColor: IconColorOption,
     onClick: () -> Unit,
     onLongClick: (() -> Unit)?,
-    isActive: Boolean = false
+    isActive: Boolean = false,
+    activeHighlightScale: Float
 ) {
     val iconStyle = when {
         displayStyle == AppDisplayStyleOption.TEXT_ONLY -> AppIconStyleOption.HIDDEN
@@ -157,7 +171,7 @@ private fun AppGridItem(
         else -> AppIconStyleOption.ORIGINAL
     }
 
-    val scale = if (isActive) 1.06f else 1.0f
+    val scale = if (isActive) activeHighlightScale else 1.0f
 
     when (displayStyle) {
         AppDisplayStyleOption.ICON_ONLY -> {

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -337,7 +337,8 @@ fun HomeScreen(
                                 },
                                 keyPrefix = "pinned",
                                 activeGlobalIndex = activeGlobalIndex,
-                                sectionGlobalStartIndex = 0
+                                sectionGlobalStartIndex = 0,
+                                activeHighlightScale = uiState.fastScrollerActiveItemScale
                             )
 
                             if (uiState.pinnedAppsLayout == com.talauncher.data.model.AppSectionLayoutOption.LIST) {
@@ -376,7 +377,8 @@ fun HomeScreen(
                                 },
                                 keyPrefix = "recent",
                                 activeGlobalIndex = activeGlobalIndex,
-                                sectionGlobalStartIndex = uiState.pinnedApps.size
+                                sectionGlobalStartIndex = uiState.pinnedApps.size,
+                                activeHighlightScale = uiState.fastScrollerActiveItemScale
                             )
                             if (uiState.allAppsLayout == com.talauncher.data.model.AppSectionLayoutOption.LIST) {
                                 item {
@@ -409,7 +411,8 @@ fun HomeScreen(
                             },
                             keyPrefix = "all",
                             activeGlobalIndex = activeGlobalIndex,
-                            sectionGlobalStartIndex = uiState.pinnedApps.size + uiState.recentApps.size
+                            sectionGlobalStartIndex = uiState.pinnedApps.size + uiState.recentApps.size,
+                            activeHighlightScale = uiState.fastScrollerActiveItemScale
                         )
 
                         if (uiState.hiddenApps.isNotEmpty()) {

--- a/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeViewModel.kt
@@ -292,7 +292,8 @@ class HomeViewModel(
                             // Sidebar customization from settings
                             sidebarActiveScale = settings?.sidebarActiveScale ?: 1.4f,
                             sidebarPopOutDp = settings?.sidebarPopOutDp ?: 16,
-                            sidebarWaveSpread = settings?.sidebarWaveSpread ?: 1.5f
+                            sidebarWaveSpread = settings?.sidebarWaveSpread ?: 1.5f,
+                            fastScrollerActiveItemScale = settings?.fastScrollerActiveItemScale ?: 1.06f
                         ).let { updated ->
                             val keepExpanded = wasExpanded && hiddenApps.isNotEmpty()
                             if (updated.isOtherAppsExpanded != keepExpanded) {
@@ -1128,6 +1129,7 @@ data class HomeUiState(
     val sidebarActiveScale: Float = 1.4f,
     val sidebarPopOutDp: Int = 16,
     val sidebarWaveSpread: Float = 1.5f,
+    val fastScrollerActiveItemScale: Float = 1.06f,
     val showAppActionDialog: Boolean = false,
     val selectedAppForAction: AppInfo? = null,
     val selectedAppSupportsUninstall: Boolean = false,

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
@@ -178,7 +178,9 @@ fun SettingsScreen(
                 sidebarPopOutDp = uiState.sidebarPopOutDp,
                 onUpdateSidebarPopOutDp = viewModel::updateSidebarPopOutDp,
                 sidebarWaveSpread = uiState.sidebarWaveSpread,
-                onUpdateSidebarWaveSpread = viewModel::updateSidebarWaveSpread
+                onUpdateSidebarWaveSpread = viewModel::updateSidebarWaveSpread,
+                fastScrollerActiveItemScale = uiState.fastScrollerActiveItemScale,
+                onUpdateFastScrollerActiveItemScale = viewModel::updateFastScrollerActiveItemScale
             )
             3 -> DistractingAppsSettingsScreen(
                 uiState = uiState,

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
@@ -105,6 +105,7 @@ class SettingsViewModel(
                     sidebarActiveScale = settings?.sidebarActiveScale ?: 1.4f,
                     sidebarPopOutDp = settings?.sidebarPopOutDp ?: 16,
                     sidebarWaveSpread = settings?.sidebarWaveSpread ?: 1.5f,
+                    fastScrollerActiveItemScale = settings?.fastScrollerActiveItemScale ?: 1.06f,
                     availableApps = allInstalledApps,
                     isLoading = false
                 )
@@ -309,6 +310,12 @@ class SettingsViewModel(
         }
     }
 
+    fun updateFastScrollerActiveItemScale(scale: Float) {
+        viewModelScope.launch {
+            settingsRepository.updateFastScrollerActiveItemScale(scale)
+        }
+    }
+
     fun updateWeatherDisplay(display: WeatherDisplayOption) {
         viewModelScope.launch {
             settingsRepository.updateWeatherDisplay(display)
@@ -457,5 +464,6 @@ data class SettingsUiState(
     // Sidebar customization
     val sidebarActiveScale: Float = 1.4f,
     val sidebarPopOutDp: Int = 16,
-    val sidebarWaveSpread: Float = 1.5f
+    val sidebarWaveSpread: Float = 1.5f,
+    val fastScrollerActiveItemScale: Float = 1.06f
 )

--- a/app/src/main/java/com/talauncher/ui/settings/UIThemeSettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/UIThemeSettingsScreen.kt
@@ -50,7 +50,9 @@ fun UIThemeSettingsScreen(
     sidebarPopOutDp: Int,
     onUpdateSidebarPopOutDp: (Int) -> Unit,
     sidebarWaveSpread: Float,
-    onUpdateSidebarWaveSpread: (Float) -> Unit
+    onUpdateSidebarWaveSpread: (Float) -> Unit,
+    fastScrollerActiveItemScale: Float,
+    onUpdateFastScrollerActiveItemScale: (Float) -> Unit
 ) {
     val sections = listOf(
         CollapsibleSection(
@@ -124,7 +126,9 @@ fun UIThemeSettingsScreen(
                 popOutDp = sidebarPopOutDp,
                 onPopOutDpChange = onUpdateSidebarPopOutDp,
                 waveSpread = sidebarWaveSpread,
-                onWaveSpreadChange = onUpdateSidebarWaveSpread
+                onWaveSpreadChange = onUpdateSidebarWaveSpread,
+                activeItemScale = fastScrollerActiveItemScale,
+                onActiveItemScaleChange = onUpdateFastScrollerActiveItemScale
             )
         }
     )
@@ -338,7 +342,9 @@ private fun SidebarSettingsContent(
     popOutDp: Int,
     onPopOutDpChange: (Int) -> Unit,
     waveSpread: Float,
-    onWaveSpreadChange: (Float) -> Unit
+    onWaveSpreadChange: (Float) -> Unit,
+    activeItemScale: Float,
+    onActiveItemScaleChange: (Float) -> Unit
 ) {
     SettingsSectionCard(title = stringResource(R.string.settings_sidebar_title)) {
         Text(
@@ -365,6 +371,16 @@ private fun SidebarSettingsContent(
             valueRange = 0f..48f,
             onValueChangeFinished = { onPopOutDpChange(popOut.toInt()) },
             valueLabel = "${popOut.toInt()} dp"
+        )
+
+        var highlightScale by remember { mutableStateOf(activeItemScale) }
+        SliderSetting(
+            label = stringResource(R.string.settings_sidebar_highlight_scale),
+            value = highlightScale,
+            onValueChange = { highlightScale = it },
+            valueRange = 1.0f..1.2f,
+            onValueChangeFinished = { onActiveItemScaleChange(highlightScale) },
+            valueLabel = String.format("%.2fx", highlightScale)
         )
 
         var spread by remember { mutableStateOf(waveSpread) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,6 +241,7 @@
     <string name="settings_sidebar_subtitle">Control how the alphabetical sidebar feels</string>
     <string name="settings_sidebar_active_scale">Active letter size</string>
     <string name="settings_sidebar_popout">Active letter pop-out</string>
+    <string name="settings_sidebar_highlight_scale">Highlighted app size</string>
     <string name="settings_sidebar_wave_spread">Wave effect size</string>
 
 


### PR DESCRIPTION
## Summary
- add a persisted fast scroller highlight scale preference with database migration and repository wiring
- expose a new sidebar settings slider so users can adjust the highlighted app size while scrubbing
- apply the configurable scale when rendering list and grid app items that are targeted by the fast scroller

## Testing
- `./gradlew lint` *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e02d3bdb68832198b5a789ec6427f1