### PR TITLE
Expand sidebar customization ranges

### DIFF
--- a/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
@@ -225,19 +225,19 @@ class SettingsRepository(private val settingsDao: SettingsDao) {
     // Sidebar / Alphabet Index customization
     suspend fun updateSidebarActiveScale(scale: Float) {
         val settings = getSettingsSync()
-        val clamped = scale.coerceIn(1.0f, 2.5f)
+        val clamped = scale.coerceIn(1.0f, 3.0f)
         updateSettings(settings.copy(sidebarActiveScale = clamped))
     }
 
     suspend fun updateSidebarPopOutDp(popOut: Int) {
         val settings = getSettingsSync()
-        val clamped = popOut.coerceIn(0, 48)
+        val clamped = popOut.coerceIn(0, 64)
         updateSettings(settings.copy(sidebarPopOutDp = clamped))
     }
 
     suspend fun updateSidebarWaveSpread(spread: Float) {
         val settings = getSettingsSync()
-        val clamped = spread.coerceIn(0.0f, 4.0f)
+        val clamped = spread.coerceIn(0.0f, 5.0f)
         updateSettings(settings.copy(sidebarWaveSpread = clamped))
     }
 }

--- a/app/src/main/java/com/talauncher/ui/settings/UIThemeSettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/UIThemeSettingsScreen.kt
@@ -352,7 +352,7 @@ private fun SidebarSettingsContent(
             label = stringResource(R.string.settings_sidebar_active_scale),
             value = scale,
             onValueChange = { scale = it },
-            valueRange = 1.0f..2.5f,
+            valueRange = 1.0f..3.0f,
             onValueChangeFinished = { onActiveScaleChange(scale) },
             valueLabel = String.format("%.2fx", scale)
         )
@@ -362,7 +362,7 @@ private fun SidebarSettingsContent(
             label = stringResource(R.string.settings_sidebar_popout),
             value = popOut,
             onValueChange = { popOut = it },
-            valueRange = 0f..48f,
+            valueRange = 0f..64f,
             onValueChangeFinished = { onPopOutDpChange(popOut.toInt()) },
             valueLabel = "${popOut.toInt()} dp"
         )
@@ -372,7 +372,7 @@ private fun SidebarSettingsContent(
             label = stringResource(R.string.settings_sidebar_wave_spread),
             value = spread,
             onValueChange = { spread = it },
-            valueRange = 0.0f..4.0f,
+            valueRange = 0.0f..5.0f,
             onValueChangeFinished = { onWaveSpreadChange(spread) },
             valueLabel = String.format("%.2f", spread)
         )


### PR DESCRIPTION
## Summary
- extend the sidebar active scale slider to allow up to 3x sizing
- expand pop-out and wave spread controls for the sidebar to offer broader customization
- update repository clamping logic to match the new slider ranges

## Testing
- ./gradlew test *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e02d1b61d4832196fdd135ff18ef46