### PR TITLE
feat: add search display settings and rename All Apps to All Apps List

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ Modern launchers are designed to keep you engaged—often at the cost of your at
 - **Tooling:** Gradle, ktlint, and a growing automated test suite (unit + instrumentation)
 ## Roadmap
 - **Grid Layout**
-- **Widgets** 
+- **Widgets** music, calendar, news headlines, weather
 - **PWA** 
 - **Distracting app features** 
+- ** AI app suggestions**
+- ** Recent apps ** recently installed (past 2 days) on/off in suggestions
 
 ## Getting Started
 1. **Install prerequisites**

--- a/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
+++ b/app/src/main/java/com/talauncher/data/database/LauncherDatabase.kt
@@ -13,7 +13,7 @@ import com.talauncher.data.model.SearchInteractionEntity
 
 @Database(
     entities = [AppInfo::class, LauncherSettings::class, AppSession::class, SearchInteractionEntity::class],
-    version = 21,
+    version = 22,
     exportSchema = false
 )
 abstract class LauncherDatabase : RoomDatabase() {
@@ -292,6 +292,20 @@ abstract class LauncherDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_21_22 = object : Migration(21, 22) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE launcher_settings ADD COLUMN searchLayout TEXT NOT NULL DEFAULT 'LIST'"
+                )
+                database.execSQL(
+                    "ALTER TABLE launcher_settings ADD COLUMN searchDisplayStyle TEXT NOT NULL DEFAULT 'ICON_AND_TEXT'"
+                )
+                database.execSQL(
+                    "ALTER TABLE launcher_settings ADD COLUMN searchIconColor TEXT NOT NULL DEFAULT 'ORIGINAL'"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): LauncherDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -317,7 +331,8 @@ abstract class LauncherDatabase : RoomDatabase() {
                     MIGRATION_16_17,
                     MIGRATION_17_18,
                     MIGRATION_18_19,
-                    MIGRATION_20_21
+                    MIGRATION_20_21,
+                    MIGRATION_21_22
                 ).build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
+++ b/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
@@ -61,6 +61,10 @@ data class LauncherSettings(
     val allAppsDisplayStyle: AppDisplayStyleOption = AppDisplayStyleOption.ICON_AND_TEXT,
     val allAppsIconColor: IconColorOption = IconColorOption.ORIGINAL,
 
+    val searchLayout: AppSectionLayoutOption = AppSectionLayoutOption.LIST,
+    val searchDisplayStyle: AppDisplayStyleOption = AppDisplayStyleOption.ICON_AND_TEXT,
+    val searchIconColor: IconColorOption = IconColorOption.ORIGINAL,
+
     // Sidebar (Alphabet Index) customization
     // How large the active letter scales (1.0 = no scale)
     val sidebarActiveScale: Float = 1.4f,

--- a/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
@@ -222,6 +222,21 @@ class SettingsRepository(private val settingsDao: SettingsDao) {
         updateSettings(settings.copy(allAppsIconColor = color))
     }
 
+    suspend fun updateSearchLayout(layout: AppSectionLayoutOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(searchLayout = layout))
+    }
+
+    suspend fun updateSearchDisplayStyle(style: AppDisplayStyleOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(searchDisplayStyle = style))
+    }
+
+    suspend fun updateSearchIconColor(color: IconColorOption) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(searchIconColor = color))
+    }
+
     // Sidebar / Alphabet Index customization
     suspend fun updateSidebarActiveScale(scale: Float) {
         val settings = getSettingsSync()

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
@@ -178,7 +178,13 @@ fun SettingsScreen(
                 allAppsDisplayStyle = uiState.allAppsDisplayStyle,
                 onUpdateAllAppsDisplayStyle = viewModel::updateAllAppsDisplayStyle,
                 allAppsIconColor = uiState.allAppsIconColor,
-                onUpdateAllAppsIconColor = viewModel::updateAllAppsIconColor
+                onUpdateAllAppsIconColor = viewModel::updateAllAppsIconColor,
+                searchLayout = uiState.searchLayout,
+                onUpdateSearchLayout = viewModel::updateSearchLayout,
+                searchDisplayStyle = uiState.searchDisplayStyle,
+                onUpdateSearchDisplayStyle = viewModel::updateSearchDisplayStyle,
+                searchIconColor = uiState.searchIconColor,
+                onUpdateSearchIconColor = viewModel::updateSearchIconColor
             )
             2 -> DistractingAppsSettingsScreen(
                 uiState = uiState,

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
@@ -101,6 +101,10 @@ class SettingsViewModel(
                     allAppsDisplayStyle = settings?.allAppsDisplayStyle ?: AppDisplayStyleOption.ICON_AND_TEXT,
                     allAppsIconColor = settings?.allAppsIconColor ?: IconColorOption.ORIGINAL,
 
+                    searchLayout = settings?.searchLayout ?: AppSectionLayoutOption.LIST,
+                    searchDisplayStyle = settings?.searchDisplayStyle ?: AppDisplayStyleOption.ICON_AND_TEXT,
+                    searchIconColor = settings?.searchIconColor ?: IconColorOption.ORIGINAL,
+
                     // Sidebar settings
                     sidebarActiveScale = settings?.sidebarActiveScale ?: 1.4f,
                     sidebarPopOutDp = settings?.sidebarPopOutDp ?: 16,
@@ -388,6 +392,24 @@ class SettingsViewModel(
         }
     }
 
+    fun updateSearchLayout(layout: AppSectionLayoutOption) {
+        viewModelScope.launch {
+            settingsRepository.updateSearchLayout(layout)
+        }
+    }
+
+    fun updateSearchDisplayStyle(style: AppDisplayStyleOption) {
+        viewModelScope.launch {
+            settingsRepository.updateSearchDisplayStyle(style)
+        }
+    }
+
+    fun updateSearchIconColor(color: IconColorOption) {
+        viewModelScope.launch {
+            settingsRepository.updateSearchIconColor(color)
+        }
+    }
+
 
     fun updateSearchQuery(query: String) {
         _uiState.value = _uiState.value.copy(searchQuery = query)
@@ -460,6 +482,10 @@ data class SettingsUiState(
     val allAppsLayout: AppSectionLayoutOption = AppSectionLayoutOption.LIST,
     val allAppsDisplayStyle: AppDisplayStyleOption = AppDisplayStyleOption.ICON_AND_TEXT,
     val allAppsIconColor: IconColorOption = IconColorOption.ORIGINAL,
+
+    val searchLayout: AppSectionLayoutOption = AppSectionLayoutOption.LIST,
+    val searchDisplayStyle: AppDisplayStyleOption = AppDisplayStyleOption.ICON_AND_TEXT,
+    val searchIconColor: IconColorOption = IconColorOption.ORIGINAL,
 
     // Sidebar customization
     val sidebarActiveScale: Float = 1.4f,

--- a/app/src/main/java/com/talauncher/ui/settings/UIThemeSettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/UIThemeSettingsScreen.kt
@@ -79,7 +79,14 @@ fun UIThemeSettingsScreen(
     allAppsDisplayStyle: AppDisplayStyleOption,
     onUpdateAllAppsDisplayStyle: (AppDisplayStyleOption) -> Unit,
     allAppsIconColor: IconColorOption,
-    onUpdateAllAppsIconColor: (IconColorOption) -> Unit
+    onUpdateAllAppsIconColor: (IconColorOption) -> Unit,
+    // App Sections settings - Search
+    searchLayout: AppSectionLayoutOption,
+    onUpdateSearchLayout: (AppSectionLayoutOption) -> Unit,
+    searchDisplayStyle: AppDisplayStyleOption,
+    onUpdateSearchDisplayStyle: (AppDisplayStyleOption) -> Unit,
+    searchIconColor: IconColorOption,
+    onUpdateSearchIconColor: (IconColorOption) -> Unit
 ) {
     val sections = listOf(
         CollapsibleSection(
@@ -189,7 +196,7 @@ fun UIThemeSettingsScreen(
         },
         CollapsibleSection(
             id = "all_apps",
-            title = stringResource(R.string.settings_all_apps)
+            title = stringResource(R.string.settings_all_apps_list)
         ) {
             AppSectionContent(
                 layout = allAppsLayout,
@@ -198,6 +205,19 @@ fun UIThemeSettingsScreen(
                 onUpdateDisplayStyle = onUpdateAllAppsDisplayStyle,
                 iconColor = allAppsIconColor,
                 onUpdateIconColor = onUpdateAllAppsIconColor
+            )
+        },
+        CollapsibleSection(
+            id = "search",
+            title = stringResource(R.string.settings_search)
+        ) {
+            AppSectionContent(
+                layout = searchLayout,
+                onUpdateLayout = onUpdateSearchLayout,
+                displayStyle = searchDisplayStyle,
+                onUpdateDisplayStyle = onUpdateSearchDisplayStyle,
+                iconColor = searchIconColor,
+                onUpdateIconColor = onUpdateSearchIconColor
             )
         }
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,7 +154,8 @@
     <string name="settings_app_sections">App Sections</string>
     <string name="settings_pinned_apps">Pinned Apps</string>
     <string name="settings_recent_apps">Recent Apps</string>
-    <string name="settings_all_apps">All Apps</string>
+    <string name="settings_all_apps_list">All Apps List</string>
+    <string name="settings_search">Search</string>
 
     <string name="settings_section_layout">Layout</string>
     <string name="settings_section_layout_subtitle">Choose how apps are arranged</string>


### PR DESCRIPTION
## Summary
- Add search section with customizable layout, display style, and icon color options
- Rename "All Apps" section to "All Apps List" for better clarity
- Add database migration (v21 -> v22) for new search settings columns

## Changes Made
### New Features
- Added "Search" settings section in UI & Theme tab with the following customization options:
  - Layout: List, Grid (3 per row), Grid (4 per row)
  - Display Style: Icon only, Icon and text, Text only
  - Icon Color: Original, Themed

### UI Improvements
- Renamed "All Apps" section to "All Apps List" to distinguish it from the general app list

### Backend Changes
- Added `searchLayout`, `searchDisplayStyle`, and `searchIconColor` fields to `LauncherSettings` entity
- Created database migration `MIGRATION_21_22` to add new columns
- Added repository methods: `updateSearchLayout`, `updateSearchDisplayStyle`, `updateSearchIconColor`
- Added ViewModel methods to handle search settings updates
- Wired up all settings through SettingsScreen to UIThemeSettingsScreen

## Technical Details
- Database version incremented from 21 to 22
- All new fields have sensible defaults (LIST, ICON_AND_TEXT, ORIGINAL)
- Uses existing `AppSectionContent` composable for consistent UI
- Follows the same pattern as existing app section settings

## Test plan
- [x] Build passes successfully
- [ ] Settings screen displays new "Search" section
- [ ] Search customization options can be changed and persist
- [ ] "All Apps List" label appears correctly
- [ ] Database migration runs successfully on existing installations
- [ ] Search results display according to selected settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)