### PR TITLE
Ensure date is displayed even without weather data

### DIFF
--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -167,7 +167,7 @@ fun HomeScreen(
                             color = MaterialTheme.colorScheme.onBackground
                         )
 
-                        // Weather display next to time; date shows under weather
+                        // Weather display next to time
                         if (uiState.weatherDisplay != WeatherDisplayOption.OFF && uiState.weatherData != null) {
                             Spacer(modifier = Modifier.width(12.dp))
                             val shouldShowTemperature = uiState.weatherDisplay != WeatherDisplayOption.DAILY ||
@@ -180,18 +180,22 @@ fun HomeScreen(
                                     dailyHigh = if (uiState.weatherDisplay == WeatherDisplayOption.DAILY) uiState.weatherDailyHigh else null,
                                     dailyLow = if (uiState.weatherDisplay == WeatherDisplayOption.DAILY) uiState.weatherDailyLow else null
                                 )
-                                if (uiState.showDate) {
-                                    Spacer(modifier = Modifier.height(PrimerSpacing.xs))
-                                    Text(
-                                        text = uiState.currentDate,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        textAlign = TextAlign.Start,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
                             }
                         }
                     }
+                }
+
+                if (uiState.showDate) {
+                    if (uiState.showTime) {
+                        Spacer(modifier = Modifier.height(PrimerSpacing.xs))
+                    }
+                    Text(
+                        text = uiState.currentDate,
+                        style = MaterialTheme.typography.bodySmall,
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.fillMaxWidth()
+                    )
                 }
             }
 


### PR DESCRIPTION
## Summary
- show the date independently of the weather widget so it is always visible when enabled
- keep the weather display alongside the time while centering the date beneath the time row

## Testing
- ./gradlew lintDebug *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e10b74e6608321bcb8277946c24f76