### PR TITLE
Show only contact name in grid mode (search/actions)

### DIFF
--- a/app/src/main/java/com/talauncher/ui/components/ContactItem.kt
+++ b/app/src/main/java/com/talauncher/ui/components/ContactItem.kt
@@ -165,28 +165,7 @@ fun ContactGridItem(
             .padding(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        // Contact initial in a circle
-        Surface(
-            modifier = Modifier
-                .size(56.dp)
-                .clip(CircleShape),
-            color = PrimerGreen.copy(alpha = 0.1f),
-            border = BorderStroke(2.dp, PrimerGreen.copy(alpha = 0.3f))
-        ) {
-            Box(
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = contact.name.firstOrNull()?.uppercase() ?: "?",
-                    style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-                    color = PrimerGreen
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        // Contact name
+        // Grid mode: show only the contact name (no icon or phone number)
         Text(
             text = contact.name,
             style = MaterialTheme.typography.bodyMedium,


### PR DESCRIPTION
This PR ensures contacts render name-only in grid mode.\n\n- Grid search: ContactGridItem shows only the contact name (no initials icon, no phone number).\n- List mode remains unchanged (initial + phone as before).\n- Actions behavior unchanged; respects showPhoneAction, showMessageAction, showWhatsAppAction.\n- Honors settings: applies when searchLayout is Grid (3/4).\n\nRationale: Aligns with TALauncher’s text-centric minimalism and reduces visual noise in grid layouts.