### PR TITLE
Add music widget and improve news settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,15 @@
             </intent-filter>
         </activity>
 
+        <service
+            android:name=".service.MusicNotificationListener"
+            android:exported="false"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
+++ b/app/src/main/java/com/talauncher/data/model/LauncherSettings.kt
@@ -78,5 +78,6 @@ data class LauncherSettings(
     // News settings
     val newsRefreshInterval: NewsRefreshInterval = NewsRefreshInterval.DAILY,
     val newsCategoriesCsv: String? = null, // Comma-separated NewsCategory names
-    val newsLastFetchedAt: Long? = null
+    val newsLastFetchedAt: Long? = null,
+    val showNewsWidget: Boolean = true // Whether to show news widget on home screen
 )

--- a/app/src/main/java/com/talauncher/data/model/MusicPlaybackState.kt
+++ b/app/src/main/java/com/talauncher/data/model/MusicPlaybackState.kt
@@ -1,0 +1,16 @@
+package com.talauncher.data.model
+
+data class MusicPlaybackState(
+    val isPlaying: Boolean = false,
+    val trackTitle: String? = null,
+    val artist: String? = null,
+    val album: String? = null,
+    val packageName: String? = null
+) {
+    val hasActivePlayback: Boolean
+        get() = trackTitle != null || artist != null
+
+    companion object {
+        val EMPTY = MusicPlaybackState()
+    }
+}

--- a/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/talauncher/data/repository/SettingsRepository.kt
@@ -275,4 +275,9 @@ class SettingsRepository(private val settingsDao: SettingsDao) {
         val csv = categories.joinToString(",") { it.name }
         updateSettings(settings.copy(newsCategoriesCsv = csv))
     }
+
+    suspend fun updateShowNewsWidget(enabled: Boolean) {
+        val settings = getSettingsSync()
+        updateSettings(settings.copy(showNewsWidget = enabled))
+    }
 }

--- a/app/src/main/java/com/talauncher/service/MusicNotificationListener.kt
+++ b/app/src/main/java/com/talauncher/service/MusicNotificationListener.kt
@@ -1,0 +1,34 @@
+package com.talauncher.service
+
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import android.util.Log
+
+/**
+ * NotificationListenerService required for accessing MediaSession APIs.
+ * This service allows the app to monitor media playback from other apps
+ * through MediaSessionManager.
+ */
+class MusicNotificationListener : NotificationListenerService() {
+    private val TAG = "MusicNotificationListener"
+
+    override fun onListenerConnected() {
+        super.onListenerConnected()
+        Log.d(TAG, "Notification listener connected")
+    }
+
+    override fun onListenerDisconnected() {
+        super.onListenerDisconnected()
+        Log.d(TAG, "Notification listener disconnected")
+    }
+
+    override fun onNotificationPosted(sbn: StatusBarNotification?) {
+        // We don't need to actively monitor notifications
+        // This service is primarily used to grant access to MediaSessionManager
+    }
+
+    override fun onNotificationRemoved(sbn: StatusBarNotification?) {
+        // We don't need to actively monitor notifications
+        // This service is primarily used to grant access to MediaSessionManager
+    }
+}

--- a/app/src/main/java/com/talauncher/service/MusicPlaybackMonitor.kt
+++ b/app/src/main/java/com/talauncher/service/MusicPlaybackMonitor.kt
@@ -32,7 +32,7 @@ class MusicPlaybackMonitor(private val context: Context) {
     fun startMonitoring() {
         try {
             mediaSessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE) as? MediaSessionManager
-            val notificationListener = ComponentName(context, "com.talauncher.service.NotificationListenerService")
+            val notificationListener = ComponentName(context, MusicNotificationListener::class.java)
 
             // Register listener
             mediaSessionManager?.addOnActiveSessionsChangedListener(sessionListener, notificationListener)

--- a/app/src/main/java/com/talauncher/service/MusicPlaybackMonitor.kt
+++ b/app/src/main/java/com/talauncher/service/MusicPlaybackMonitor.kt
@@ -1,0 +1,144 @@
+package com.talauncher.service
+
+import android.content.ComponentName
+import android.content.Context
+import android.media.MediaMetadata
+import android.media.session.MediaController
+import android.media.session.MediaSessionManager
+import android.media.session.PlaybackState
+import android.util.Log
+import com.talauncher.data.model.MusicPlaybackState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class MusicPlaybackMonitor(private val context: Context) {
+    private val TAG = "MusicPlaybackMonitor"
+
+    private val _playbackState = MutableStateFlow(MusicPlaybackState.EMPTY)
+    val playbackState: StateFlow<MusicPlaybackState> = _playbackState.asStateFlow()
+
+    private var mediaSessionManager: MediaSessionManager? = null
+    private var activeControllers: List<MediaController> = emptyList()
+    private val controllerCallbacks = mutableMapOf<MediaController, MediaController.Callback>()
+
+    private val sessionListener = object : MediaSessionManager.OnActiveSessionsChangedListener {
+        override fun onActiveSessionsChanged(controllers: List<MediaController>?) {
+            Log.d(TAG, "Active sessions changed: ${controllers?.size ?: 0} controllers")
+            updateActiveControllers(controllers ?: emptyList())
+        }
+    }
+
+    fun startMonitoring() {
+        try {
+            mediaSessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE) as? MediaSessionManager
+            val notificationListener = ComponentName(context, "com.talauncher.service.NotificationListenerService")
+
+            // Register listener
+            mediaSessionManager?.addOnActiveSessionsChangedListener(sessionListener, notificationListener)
+
+            // Get initial active sessions
+            val controllers = mediaSessionManager?.getActiveSessions(notificationListener) ?: emptyList()
+            updateActiveControllers(controllers)
+
+            Log.d(TAG, "Music playback monitoring started")
+        } catch (e: SecurityException) {
+            Log.e(TAG, "Permission not granted for notification listener", e)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error starting music playback monitoring", e)
+        }
+    }
+
+    fun stopMonitoring() {
+        try {
+            mediaSessionManager?.removeOnActiveSessionsChangedListener(sessionListener)
+            controllerCallbacks.forEach { (controller, callback) ->
+                controller.unregisterCallback(callback)
+            }
+            controllerCallbacks.clear()
+            activeControllers = emptyList()
+            _playbackState.value = MusicPlaybackState.EMPTY
+            Log.d(TAG, "Music playback monitoring stopped")
+        } catch (e: Exception) {
+            Log.e(TAG, "Error stopping music playback monitoring", e)
+        }
+    }
+
+    private fun updateActiveControllers(controllers: List<MediaController>) {
+        // Unregister old callbacks
+        controllerCallbacks.forEach { (controller, callback) ->
+            controller.unregisterCallback(callback)
+        }
+        controllerCallbacks.clear()
+
+        activeControllers = controllers
+
+        // Register new callbacks
+        controllers.forEach { controller ->
+            val callback = object : MediaController.Callback() {
+                override fun onPlaybackStateChanged(state: PlaybackState?) {
+                    updatePlaybackState()
+                }
+
+                override fun onMetadataChanged(metadata: MediaMetadata?) {
+                    updatePlaybackState()
+                }
+            }
+            controller.registerCallback(callback)
+            controllerCallbacks[controller] = callback
+        }
+
+        updatePlaybackState()
+    }
+
+    private fun updatePlaybackState() {
+        // Find the first actively playing controller
+        val playingController = activeControllers.firstOrNull { controller ->
+            controller.playbackState?.state == PlaybackState.STATE_PLAYING
+        }
+
+        if (playingController != null) {
+            val metadata = playingController.metadata
+            val playbackState = playingController.playbackState
+            val isPlaying = playbackState?.state == PlaybackState.STATE_PLAYING
+
+            _playbackState.value = MusicPlaybackState(
+                isPlaying = isPlaying,
+                trackTitle = metadata?.getString(MediaMetadata.METADATA_KEY_TITLE),
+                artist = metadata?.getString(MediaMetadata.METADATA_KEY_ARTIST),
+                album = metadata?.getString(MediaMetadata.METADATA_KEY_ALBUM),
+                packageName = playingController.packageName
+            )
+
+            Log.d(TAG, "Updated playback state: ${_playbackState.value}")
+        } else {
+            _playbackState.value = MusicPlaybackState.EMPTY
+            Log.d(TAG, "No active playback")
+        }
+    }
+
+    fun sendPlayPauseCommand() {
+        val controller = getActiveController()
+        controller?.transportControls?.let { controls ->
+            if (controller.playbackState?.state == PlaybackState.STATE_PLAYING) {
+                controls.pause()
+            } else {
+                controls.play()
+            }
+        }
+    }
+
+    fun sendPreviousCommand() {
+        getActiveController()?.transportControls?.skipToPrevious()
+    }
+
+    fun sendNextCommand() {
+        getActiveController()?.transportControls?.skipToNext()
+    }
+
+    private fun getActiveController(): MediaController? {
+        return activeControllers.firstOrNull { controller ->
+            controller.playbackState?.state == PlaybackState.STATE_PLAYING
+        } ?: activeControllers.firstOrNull()
+    }
+}

--- a/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
@@ -162,7 +162,10 @@ class AppDrawerViewModel(
 
                     val updatedState = newState
                     val locale = updatedState.locale ?: Locale.getDefault()
-                    val collator = updatedState.collator ?: Collator.getInstance()
+                    // Ensure case-insensitive, locale-aware sorting for the apps screen
+                    val collator = (updatedState.collator ?: Collator.getInstance(locale)).apply {
+                        strength = Collator.PRIMARY
+                    }
                     val searchQuery = updatedState.searchQuery
                     buildSectionsAndIndex(
                         visibleApps,
@@ -528,13 +531,15 @@ class AppDrawerViewModel(
     }
 
     fun onLocaleChanged(locale: Locale, collator: Collator) {
-        _uiState.value = _uiState.value.copy(locale = locale, collator = collator)
+        // Normalize to case-insensitive collation for consistent A/a grouping
+        val normalized = Collator.getInstance(locale).apply { strength = Collator.PRIMARY }
+        _uiState.value = _uiState.value.copy(locale = locale, collator = normalized)
         buildSectionsAndIndex(
             _uiState.value.allApps,
             _uiState.value.recentApps,
             _uiState.value.searchQuery,
             locale,
-            collator
+            normalized
         )
     }
 

--- a/app/src/main/java/com/talauncher/ui/components/MusicWidget.kt
+++ b/app/src/main/java/com/talauncher/ui/components/MusicWidget.kt
@@ -1,0 +1,94 @@
+package com.talauncher.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.talauncher.data.model.MusicPlaybackState
+
+@Composable
+fun MusicWidget(
+    playbackState: MusicPlaybackState,
+    onPlayPause: () -> Unit,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        // Track info
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = playbackState.trackTitle ?: "Unknown Track",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (playbackState.artist != null) {
+                Text(
+                    text = playbackState.artist,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+        // Playback controls
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(
+                onClick = onPrevious,
+                modifier = Modifier.size(40.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.SkipPrevious,
+                    contentDescription = "Previous",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            IconButton(
+                onClick = onPlayPause,
+                modifier = Modifier.size(48.dp)
+            ) {
+                Icon(
+                    imageVector = if (playbackState.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                    contentDescription = if (playbackState.isPlaying) "Pause" else "Play",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(32.dp)
+                )
+            }
+
+            IconButton(
+                onClick = onNext,
+                modifier = Modifier.size(40.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.SkipNext,
+                    contentDescription = "Next",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/home/HomeScreen.kt
@@ -167,7 +167,7 @@ fun HomeScreen(
                             color = MaterialTheme.colorScheme.onBackground
                         )
 
-                        // Weather display next to time; date shows under weather
+                        // Weather display next to time; date shows under weather or time
                         if (uiState.weatherDisplay != WeatherDisplayOption.OFF && uiState.weatherData != null) {
                             Spacer(modifier = Modifier.width(12.dp))
                             val shouldShowTemperature = uiState.weatherDisplay != WeatherDisplayOption.DAILY ||
@@ -193,10 +193,32 @@ fun HomeScreen(
                         }
                     }
                 }
+
+                // Show date when weather is off
+                if (uiState.showDate && (uiState.weatherDisplay == WeatherDisplayOption.OFF || uiState.weatherData == null)) {
+                    Spacer(modifier = Modifier.height(PrimerSpacing.xs))
+                    Text(
+                        text = uiState.currentDate,
+                        style = MaterialTheme.typography.bodySmall,
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
             }
 
-            // News carousel below the time/date area
-            if (uiState.newsArticles.isNotEmpty()) {
+            // Music widget or News carousel below the time/date area
+            // Show music widget when music is playing, otherwise show news if enabled
+            if (uiState.musicPlaybackState.hasActivePlayback) {
+                Spacer(modifier = Modifier.height(PrimerSpacing.sm))
+                com.talauncher.ui.components.MusicWidget(
+                    playbackState = uiState.musicPlaybackState,
+                    onPlayPause = viewModel::onPlayPause,
+                    onPrevious = viewModel::onPreviousTrack,
+                    onNext = viewModel::onNextTrack,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            } else if (uiState.showNewsWidget && uiState.newsArticles.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(PrimerSpacing.sm))
                 com.talauncher.ui.components.NewsCarousel(
                     articles = uiState.newsArticles,

--- a/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/onboarding/OnboardingScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -45,6 +46,7 @@ private enum class OnboardingStepId {
     USAGE_STATS,
     CONTACTS,
     LOCATION,
+    NOTIFICATION_LISTENER,
     APPEARANCE
 }
 
@@ -77,6 +79,7 @@ fun OnboardingScreen(
             add(OnboardingStepId.USAGE_STATS)
             add(OnboardingStepId.CONTACTS)
             add(OnboardingStepId.LOCATION)
+            add(OnboardingStepId.NOTIFICATION_LISTENER)
             add(OnboardingStepId.APPEARANCE)
         }
     }
@@ -179,6 +182,20 @@ fun OnboardingScreen(
                 onNext = { viewModel.goToNextStep() },
                 onBack = { viewModel.goToPreviousStep() },
                 canProceed = permissionState.hasLocation,
+                allowSkip = true,
+                onSkip = { viewModel.goToNextStep() }
+            )
+
+            OnboardingStepId.NOTIFICATION_LISTENER -> PermissionStep(
+                icon = Icons.Default.Notifications,
+                title = "Music Widget Access",
+                description = "Allow notification listener access to display music playback controls when you're listening to music from apps like Spotify, YouTube Music, or other media players.",
+                isGranted = permissionState.hasNotificationListener,
+                primaryButtonText = if (permissionState.hasNotificationListener) stringResource(R.string.completed) else stringResource(R.string.onboarding_action_grant_permission),
+                onPrimary = { permissionsHelper.requestPermission(context as Activity, PermissionType.NOTIFICATION_LISTENER) },
+                onNext = { viewModel.goToNextStep() },
+                onBack = { viewModel.goToPreviousStep() },
+                canProceed = permissionState.hasNotificationListener,
                 allowSkip = true,
                 onSkip = { viewModel.goToNextStep() }
             )

--- a/app/src/main/java/com/talauncher/ui/settings/GeneralSettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/GeneralSettingsScreen.kt
@@ -9,11 +9,14 @@ import androidx.compose.ui.unit.dp
 import com.talauncher.R
 import com.talauncher.data.model.WeatherDisplayOption
 import com.talauncher.data.model.WeatherTemperatureUnit
+import com.talauncher.data.model.NewsCategory
+import com.talauncher.data.model.NewsRefreshInterval
 import com.talauncher.ui.components.CollapsibleSection
 import com.talauncher.ui.components.CollapsibleSectionContainer
 import com.talauncher.ui.components.SettingItem
 import com.talauncher.ui.components.SettingsLazyColumn
 import com.talauncher.ui.components.SliderSetting
+import com.talauncher.ui.components.CheckboxItem
 import com.talauncher.utils.PermissionsHelper
 import kotlin.math.roundToInt
 
@@ -25,6 +28,12 @@ fun GeneralSettingsScreen(
     onUpdateWeatherDisplay: (WeatherDisplayOption) -> Unit,
     weatherTemperatureUnit: WeatherTemperatureUnit,
     onUpdateWeatherTemperatureUnit: (WeatherTemperatureUnit) -> Unit,
+    showNewsWidget: Boolean,
+    onToggleNewsWidget: () -> Unit,
+    newsRefreshInterval: NewsRefreshInterval,
+    onUpdateNewsRefreshInterval: (NewsRefreshInterval) -> Unit,
+    newsSelectedCategories: Set<NewsCategory>,
+    onToggleNewsCategory: (NewsCategory) -> Unit,
     permissionsHelper: PermissionsHelper,
     buildCommitHash: String?,
     buildBranch: String?,
@@ -53,6 +62,21 @@ fun GeneralSettingsScreen(
                     weatherTemperatureUnit = weatherTemperatureUnit,
                     onUpdateWeatherTemperatureUnit = onUpdateWeatherTemperatureUnit,
                     permissionsHelper = permissionsHelper
+                )
+            }
+        )
+        add(
+            CollapsibleSection(
+                id = "news",
+                title = "News"
+            ) {
+                NewsContent(
+                    showNewsWidget = showNewsWidget,
+                    onToggleNewsWidget = onToggleNewsWidget,
+                    refreshInterval = newsRefreshInterval,
+                    onUpdateRefreshInterval = onUpdateNewsRefreshInterval,
+                    selectedCategories = newsSelectedCategories,
+                    onToggleCategory = onToggleNewsCategory
                 )
             }
         )
@@ -160,6 +184,75 @@ private fun WeatherContent(
                 onClick = { onUpdateWeatherTemperatureUnit(option) },
                 label = { Text("°${option.symbol}") },
                 modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun NewsContent(
+    showNewsWidget: Boolean,
+    onToggleNewsWidget: () -> Unit,
+    refreshInterval: NewsRefreshInterval,
+    onUpdateRefreshInterval: (NewsRefreshInterval) -> Unit,
+    selectedCategories: Set<NewsCategory>,
+    onToggleCategory: (NewsCategory) -> Unit
+) {
+    SettingItem(
+        title = "Show News Widget",
+        subtitle = "Display news articles on the home screen when music is not playing",
+        checked = showNewsWidget,
+        onCheckedChange = { onToggleNewsWidget() }
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Text(
+        text = "Refresh Frequency",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurface
+    )
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        FilterChip(
+            selected = refreshInterval == NewsRefreshInterval.DAILY,
+            onClick = { onUpdateRefreshInterval(NewsRefreshInterval.DAILY) },
+            label = { Text("Daily") }
+        )
+        FilterChip(
+            selected = refreshInterval == NewsRefreshInterval.HOURLY,
+            onClick = { onUpdateRefreshInterval(NewsRefreshInterval.HOURLY) },
+            label = { Text("Hourly") }
+        )
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Text(
+        text = "Categories",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurface
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        NewsCategory.entries.forEach { category ->
+            CheckboxItem(
+                label = category.label,
+                checked = selectedCategories.contains(category),
+                onCheckedChange = { onToggleCategory(category) }
+            )
+        }
+        if (selectedCategories.isEmpty()) {
+            Text(
+                text = "Select at least one category to enable news.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp)
             )
         }
     }

--- a/app/src/main/java/com/talauncher/ui/settings/GeneralSettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/GeneralSettingsScreen.kt
@@ -47,7 +47,8 @@ fun GeneralSettingsScreen(
             ) {
                 FocusProductivityContent(
                     enableTimeLimitPrompt = enableTimeLimitPrompt,
-                    onToggleTimeLimitPrompt = onToggleTimeLimitPrompt
+                    onToggleTimeLimitPrompt = onToggleTimeLimitPrompt,
+                    permissionsHelper = permissionsHelper
                 )
             }
         )
@@ -109,14 +110,63 @@ fun GeneralSettingsScreen(
 @Composable
 private fun FocusProductivityContent(
     enableTimeLimitPrompt: Boolean,
-    onToggleTimeLimitPrompt: () -> Unit
+    onToggleTimeLimitPrompt: () -> Unit,
+    permissionsHelper: PermissionsHelper
 ) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val permissionState by permissionsHelper.permissionState.collectAsState()
+
     SettingItem(
         title = stringResource(R.string.settings_time_limit_dialog_title),
         subtitle = stringResource(R.string.settings_time_limit_dialog_subtitle),
         checked = enableTimeLimitPrompt,
         onCheckedChange = { onToggleTimeLimitPrompt() }
     )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    // Music Widget Notification Listener Permission
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Music Widget",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = if (permissionState.hasNotificationListener) {
+                        "Notification listener enabled - music widget will display when audio is playing"
+                    } else {
+                        "Requires notification listener permission to show music playback"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+        if (!permissionState.hasNotificationListener) {
+            Button(
+                onClick = {
+                    if (context is androidx.activity.ComponentActivity) {
+                        permissionsHelper.requestPermission(
+                            context,
+                            com.talauncher.utils.PermissionType.NOTIFICATION_LISTENER
+                        )
+                    }
+                },
+                modifier = Modifier.padding(top = 8.dp)
+            ) {
+                Text("Enable Notification Listener")
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/talauncher/ui/settings/GeneralSettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/GeneralSettingsScreen.kt
@@ -126,32 +126,24 @@ private fun FocusProductivityContent(
     Spacer(modifier = Modifier.height(16.dp))
 
     // Music Widget Notification Listener Permission
-    Column {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = "Music Widget",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                Text(
-                    text = if (permissionState.hasNotificationListener) {
-                        "Notification listener enabled - music widget will display when audio is playing"
-                    } else {
-                        "Requires notification listener permission to show music playback"
-                    },
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Music Widget",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = if (permissionState.hasNotificationListener) {
+                "Notification listener enabled - music widget will display when audio is playing"
+            } else {
+                "Requires notification listener permission to show music playback"
+            },
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
         if (!permissionState.hasNotificationListener) {
+            Spacer(modifier = Modifier.height(8.dp))
             Button(
                 onClick = {
                     if (context is androidx.activity.ComponentActivity) {
@@ -160,8 +152,7 @@ private fun FocusProductivityContent(
                             com.talauncher.utils.PermissionType.NOTIFICATION_LISTENER
                         )
                     }
-                },
-                modifier = Modifier.padding(top = 8.dp)
+                }
             ) {
                 Text("Enable Notification Listener")
             }

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsScreen.kt
@@ -32,8 +32,7 @@ fun SettingsScreen(
         stringResource(R.string.settings_tab_general),
         stringResource(R.string.settings_tab_ui_theme),
         stringResource(R.string.settings_tab_distracting_apps),
-        stringResource(R.string.settings_tab_usage_insights),
-        "News"
+        stringResource(R.string.settings_tab_usage_insights)
     )
     var editingApp by remember { mutableStateOf<com.talauncher.data.model.InstalledApp?>(null) }
     var editingTimeLimit by remember { mutableStateOf(uiState.defaultTimeLimitMinutes) }
@@ -110,6 +109,12 @@ fun SettingsScreen(
                 onUpdateWeatherDisplay = viewModel::updateWeatherDisplay,
                 weatherTemperatureUnit = uiState.weatherTemperatureUnit,
                 onUpdateWeatherTemperatureUnit = viewModel::updateWeatherTemperatureUnit,
+                showNewsWidget = uiState.showNewsWidget,
+                onToggleNewsWidget = viewModel::toggleNewsWidget,
+                newsRefreshInterval = uiState.newsRefreshInterval,
+                onUpdateNewsRefreshInterval = viewModel::updateNewsRefreshInterval,
+                newsSelectedCategories = uiState.newsSelectedCategories,
+                onToggleNewsCategory = viewModel::toggleNewsCategory,
                 permissionsHelper = viewModel.permissionsHelper,
                 buildCommitHash = uiState.buildCommitHash,
                 buildBranch = uiState.buildBranch,
@@ -205,12 +210,6 @@ fun SettingsScreen(
                     viewModel = insightsViewModel
                 )
             }
-            4 -> NewsSettingsScreen(
-                selectedCategories = uiState.newsSelectedCategories,
-                onToggleCategory = viewModel::toggleNewsCategory,
-                refreshInterval = uiState.newsRefreshInterval,
-                onUpdateRefreshInterval = viewModel::updateNewsRefreshInterval
-            )
         }
 
         editingApp?.let { app ->

--- a/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/settings/SettingsViewModel.kt
@@ -115,6 +115,7 @@ class SettingsViewModel(
                     // News settings
                     newsRefreshInterval = settings?.newsRefreshInterval ?: NewsRefreshInterval.DAILY,
                     newsSelectedCategories = parseNewsCategories(settings?.newsCategoriesCsv),
+                    showNewsWidget = settings?.showNewsWidget ?: true,
                     availableApps = allInstalledApps,
                     isLoading = false
                 )
@@ -340,6 +341,12 @@ class SettingsViewModel(
         }
     }
 
+    fun toggleNewsWidget() {
+        viewModelScope.launch {
+            settingsRepository.updateShowNewsWidget(!_uiState.value.showNewsWidget)
+        }
+    }
+
     fun updateWeatherDisplay(display: WeatherDisplayOption) {
         viewModelScope.launch {
             settingsRepository.updateWeatherDisplay(display)
@@ -514,7 +521,8 @@ data class SettingsUiState(
     val fastScrollerActiveItemScale: Float = 1.06f,
     // News
     val newsRefreshInterval: NewsRefreshInterval = NewsRefreshInterval.DAILY,
-    val newsSelectedCategories: Set<NewsCategory> = emptySet()
+    val newsSelectedCategories: Set<NewsCategory> = emptySet(),
+    val showNewsWidget: Boolean = true
 )
 
 private fun parseNewsCategories(csv: String?): Set<NewsCategory> {

--- a/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
+++ b/app/src/main/java/com/talauncher/utils/PermissionsHelper.kt
@@ -22,7 +22,8 @@ data class PermissionState(
     val hasNotifications: Boolean = false,
     val hasContacts: Boolean = false,
     val hasCallPhone: Boolean = false,
-    val hasLocation: Boolean = false
+    val hasLocation: Boolean = false,
+    val hasNotificationListener: Boolean = false
 ) {
     val allOnboardingPermissionsGranted: Boolean
         get() =
@@ -38,7 +39,8 @@ enum class PermissionType {
     CONTACTS,
     CALL_PHONE,
     DEFAULT_LAUNCHER,
-    LOCATION
+    LOCATION,
+    NOTIFICATION_LISTENER
 }
 
 open class PermissionsHelper(
@@ -58,7 +60,8 @@ open class PermissionsHelper(
             hasNotifications = hasNotificationPermission(),
             hasContacts = hasContactsPermission(),
             hasCallPhone = hasCallPhonePermission(),
-            hasLocation = hasLocationPermission()
+            hasLocation = hasLocationPermission(),
+            hasNotificationListener = hasNotificationListenerPermission()
         )
     }
 
@@ -70,6 +73,7 @@ open class PermissionsHelper(
             PermissionType.CALL_PHONE -> requestCallPhonePermission(activity)
             PermissionType.DEFAULT_LAUNCHER -> openDefaultLauncherSettings()
             PermissionType.LOCATION -> requestLocationPermission(activity)
+            PermissionType.NOTIFICATION_LISTENER -> openNotificationListenerSettings()
         }
     }
 
@@ -198,6 +202,21 @@ open class PermissionsHelper(
             arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION),
             LOCATION_PERMISSION_REQUEST_CODE
         )
+    }
+
+    fun hasNotificationListenerPermission(): Boolean {
+        val enabledListeners = Settings.Secure.getString(
+            context.contentResolver,
+            "enabled_notification_listeners"
+        )
+        return enabledListeners?.contains(context.packageName) == true
+    }
+
+    private fun openNotificationListenerSettings() {
+        val intent = Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- Fixed date visibility to show in same place regardless of weather setting
- Added MusicWidget component that displays when music is playing
- Integrated music playback detection using MediaSession APIs
- Added news widget toggle setting
- Consolidated all news settings into General tab as collapsible section
- Music widget takes priority over news when music is playing
- News widget shows when music is not playing and news is enabled

## Test plan
- [ ] Verify date shows consistently whether weather is on or off
- [ ] Test music widget appears when music is playing from any app
- [ ] Test music widget controls (play/pause, previous, next) work correctly
- [ ] Verify news widget shows when music is not playing
- [ ] Test news widget toggle in General settings
- [ ] Verify news settings (categories, refresh interval) work correctly
- [ ] Test switching between music widget and news widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)