### PR TITLE
Apps: case-insensitive sorting for apps screen (list + grid)

### DIFF
--- a/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
+++ b/app/src/main/java/com/talauncher/ui/appdrawer/AppDrawerViewModel.kt
@@ -162,7 +162,10 @@ class AppDrawerViewModel(
 
                     val updatedState = newState
                     val locale = updatedState.locale ?: Locale.getDefault()
-                    val collator = updatedState.collator ?: Collator.getInstance()
+                    // Ensure case-insensitive, locale-aware sorting for the apps screen
+                    val collator = (updatedState.collator ?: Collator.getInstance(locale)).apply {
+                        strength = Collator.PRIMARY
+                    }
                     val searchQuery = updatedState.searchQuery
                     buildSectionsAndIndex(
                         visibleApps,
@@ -528,13 +531,15 @@ class AppDrawerViewModel(
     }
 
     fun onLocaleChanged(locale: Locale, collator: Collator) {
-        _uiState.value = _uiState.value.copy(locale = locale, collator = collator)
+        // Normalize to case-insensitive collation for consistent A/a grouping
+        val normalized = Collator.getInstance(locale).apply { strength = Collator.PRIMARY }
+        _uiState.value = _uiState.value.copy(locale = locale, collator = normalized)
         buildSectionsAndIndex(
             _uiState.value.allApps,
             _uiState.value.recentApps,
             _uiState.value.searchQuery,
             locale,
-            collator
+            normalized
         )
     }
 


### PR DESCRIPTION
This PR enforces case-insensitive, locale-aware sorting for the main apps screen (both list and grid layouts), while leaving search ranking/ordering unchanged.

What changed
- Use Collator.PRIMARY for app name comparisons in AppDrawerViewModel to group A/ together and ensure consistent alphabetical order across locales.
- Normalize onLocaleChanged to always use a primary-strength collator.

Not affected
- Search mode: relevance scoring and tie-breakers remain as-is; only the apps screen sorting (when search is blank) is adjusted.

Why
- Aligns with the minimal, text-forward design by producing predictable A→Z ordering regardless of case, matching user expectation that A and  appear together before B/.

Implementation details
- uildSectionsAndIndexSync already uses a Collator for ordering; we now guarantee the collator’s strength is PRIMARY when building sections and when locale changes.

QA
- Verify the main apps list/grid show A/ grouped, then B/, etc.
- Ensure search results ordering is unchanged.